### PR TITLE
DM-17041: Use colon instead of dot with -c option

### DIFF
--- a/python/lsst/ctrl/mpexec/cmdLineParser.py
+++ b/python/lsst/ctrl/mpexec/cmdLineParser.py
@@ -84,12 +84,20 @@ class _PipelineActionType:
         value = self.valueType(value)
         return _PipelineAction(self.action, label, value)
 
+    def __repr__(self):
+        """String representation of this class.
+
+        argparse can use this for some error messages, default implementation
+        makes those messages incomprehensible.
+        """
+        return f"_PipelineActionType(action={self.action})"
+
 
 _ACTION_ADD_TASK = _PipelineActionType("new_task", "(?P<value>[^:]+)(:(?P<label>.+))?")
 _ACTION_DELETE_TASK = _PipelineActionType("delete_task", "(?P<value>)(?P<label>.+)")
 _ACTION_MOVE_TASK = _PipelineActionType("move_task", r"(?P<label>.+):(?P<value>-?\d+)", int)
 _ACTION_LABEL_TASK = _PipelineActionType("relabel", "(?P<label>.+):(?P<value>.+)")
-_ACTION_CONFIG = _PipelineActionType("config", "(?P<label>[^.]+)[.](?P<value>.+=.+)")
+_ACTION_CONFIG = _PipelineActionType("config", "(?P<label>.+):(?P<value>.+=.+)")
 _ACTION_CONFIG_FILE = _PipelineActionType("configfile", "(?P<label>.+):(?P<value>.+)")
 
 
@@ -374,10 +382,10 @@ def makeParser(fromfile_prefix_chars='@', parser_class=ArgumentParser, **kwargs)
         subparser.add_argument("-l", "--label", metavar="LABEL:NEW_LABEL",
                                dest="pipeline_actions", action='append', type=_ACTION_LABEL_TASK,
                                help="Change label of a given task.")
-        subparser.add_argument("-c", "--config", metavar="LABEL.NAME=VALUE",
+        subparser.add_argument("-c", "--config", metavar="LABEL:NAME=VALUE",
                                dest="pipeline_actions", action='append', type=_ACTION_CONFIG,
                                help="Configuration override(s) for a task with specified label, "
-                               "e.g. -c task.foo=newfoo -c task.bar.baz=3.")
+                               "e.g. -c task:foo=newfoo -c task:bar.baz=3.")
         subparser.add_argument("-C", "--configfile", metavar="LABEL:PATH",
                                dest="pipeline_actions", action='append', type=_ACTION_CONFIG_FILE,
                                help="Configuration override file(s), applies to a task with a given label.")

--- a/tests/test_cmdLineParser.py
+++ b/tests/test_cmdLineParser.py
@@ -270,9 +270,9 @@ class CmdLineParserTestCase(unittest.TestCase):
             run -t taskname:label
             --show config
             --show config=Task.*
-            -c label.a=b
+            -c label:a=b
             -C label:filename1
-            -c label.c=d -c label.e=f
+            -c label:c=d -c label:e=f
             -C label:filename2 -C label:filename3
             """.split())
         self.assertTrue(args.clobberConfig)
@@ -316,12 +316,12 @@ class CmdLineParserTestCase(unittest.TestCase):
             -t task3
             -t task4
             --show config
-            -c task1.a=b
+            -c task1:a=b
             -C task1:filename1
-            -c label2.c=d -c label2.e=f
+            -c label2:c=d -c label2:e=f
             -C task3:filename2 -C task3:filename3
             --show config=Task.*
-            -C task4:filename4 -c task4.x=y
+            -C task4:filename4 -c task4:x=y
             --order-pipeline
             --save-pipeline=newpipe.pickle
             --save-qgraph=newqgraph.pickle


### PR DESCRIPTION
For consistency with other options that use task labels switching to
colon as a separator for -c option value.