### PR TITLE
Parse dictionary in command line parser (DM-17067)

### DIFF
--- a/python/lsst/ctrl/mpexec/cmdLineParser.py
+++ b/python/lsst/ctrl/mpexec/cmdLineParser.py
@@ -99,7 +99,7 @@ _ACTION_MOVE_TASK = _PipelineActionType("move_task", r"(?P<label>.+):(?P<value>-
 _ACTION_LABEL_TASK = _PipelineActionType("relabel", "(?P<label>.+):(?P<value>.+)")
 _ACTION_CONFIG = _PipelineActionType("config", "(?P<label>.+):(?P<value>.+=.+)")
 _ACTION_CONFIG_FILE = _PipelineActionType("configfile", "(?P<label>.+):(?P<value>.+)")
-_ACTION_NAME_TEMPLATES = _PipelineActionType("name_templates", "(?P<label>[^.]+):(?P<value>.+)")
+_ACTION_NAME_TEMPLATES = _PipelineActionType("name_templates", "(?P<label>[^:]+):(?P<value>.+)")
 
 
 class _LogLevelAction(Action):

--- a/python/lsst/ctrl/mpexec/cmdLineParser.py
+++ b/python/lsst/ctrl/mpexec/cmdLineParser.py
@@ -28,6 +28,7 @@ __all__ = ["makeParser"]
 #  Imports of standard modules --
 # -------------------------------
 from argparse import Action, ArgumentParser, RawDescriptionHelpFormatter
+import ast
 import collections
 import re
 import textwrap
@@ -93,13 +94,32 @@ class _PipelineActionType:
         return f"_PipelineActionType(action={self.action})"
 
 
+def _nameTemplatesType(value):
+    """Convert name_templates option value to a dictionary.
+    """
+    # try to parse value as python literal expression
+    parsedNamesDict = ast.literal_eval(value)
+    # expecting dict
+    if not isinstance(parsedNamesDict, dict):
+        raise TypeError(f"Unable parse --dataset-name-substitution {value} "
+                        "into a valid dict")
+    # check that all keys and values are strings
+    for key, val in parsedNamesDict.items():
+        for x in [key, val]:
+            if not isinstance(x, str):
+                raise TypeError(f"--dataset-name-substitution option {value} "
+                                "contains non-string key or value")
+    return parsedNamesDict
+
+
 _ACTION_ADD_TASK = _PipelineActionType("new_task", "(?P<value>[^:]+)(:(?P<label>.+))?")
 _ACTION_DELETE_TASK = _PipelineActionType("delete_task", "(?P<value>)(?P<label>.+)")
 _ACTION_MOVE_TASK = _PipelineActionType("move_task", r"(?P<label>.+):(?P<value>-?\d+)", int)
 _ACTION_LABEL_TASK = _PipelineActionType("relabel", "(?P<label>.+):(?P<value>.+)")
 _ACTION_CONFIG = _PipelineActionType("config", "(?P<label>.+):(?P<value>.+=.+)")
 _ACTION_CONFIG_FILE = _PipelineActionType("configfile", "(?P<label>.+):(?P<value>.+)")
-_ACTION_NAME_TEMPLATES = _PipelineActionType("name_templates", "(?P<label>[^:]+):(?P<value>.+)")
+_ACTION_NAME_TEMPLATES = _PipelineActionType("name_templates", "(?P<label>[^:]+):(?P<value>.+)",
+                                             _nameTemplatesType)
 
 
 class _LogLevelAction(Action):

--- a/tests/test_cmdLineParser.py
+++ b/tests/test_cmdLineParser.py
@@ -316,12 +316,14 @@ class CmdLineParserTestCase(unittest.TestCase):
             -t task3
             -t task4
             --show config
+            -m task1:2
             -c task1:a=b
             -C task1:filename1
             -c label2:c=d -c label2:e=f
             -C task3:filename2 -C task3:filename3
             --show config=Task.*
             -C task4:filename4 -c task4:x=y
+            --dataset-name-substitution task4:{"key":"value"}
             --order-pipeline
             --save-pipeline=newpipe.pickle
             --save-qgraph=newqgraph.pickle
@@ -329,10 +331,12 @@ class CmdLineParserTestCase(unittest.TestCase):
             --qgraph-dot qgraph.dot
             """.split())
         self.assertEqual(args.show, ['config', 'config=Task.*'])
+        nameTemplateVal = '{"key":"value"}'
         self.assertEqual(args.pipeline_actions, [PipelineAction("new_task", None, "task1"),
                                                  PipelineAction("new_task", "label2", "task2"),
                                                  PipelineAction("new_task", None, "task3"),
                                                  PipelineAction("new_task", None, "task4"),
+                                                 PipelineAction("move_task", "task1", 2),
                                                  PipelineAction("config", "task1", "a=b"),
                                                  PipelineAction("configfile", "task1", "filename1"),
                                                  PipelineAction("config", "label2", "c=d"),
@@ -340,7 +344,8 @@ class CmdLineParserTestCase(unittest.TestCase):
                                                  PipelineAction("configfile", "task3", "filename2"),
                                                  PipelineAction("configfile", "task3", "filename3"),
                                                  PipelineAction("configfile", "task4", "filename4"),
-                                                 PipelineAction("config", "task4", "x=y")])
+                                                 PipelineAction("config", "task4", "x=y"),
+                                                 PipelineAction("name_templates", "task4", nameTemplateVal)])
         self.assertEqual(args.pipeline, "pipeline.pickle")
         self.assertEqual(args.qgraph, "qgraph.pickle")
         self.assertTrue(args.order_pipeline)


### PR DESCRIPTION
Now the value of --dataset-name-substitution is parsed directly during
command line parsing. Added unit tests for that new feature too.
Fix parsing of dataset-name-substitution option.