### PR TITLE
DM-19769: Fix time logging with --longlog.

### DIFF
--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -155,7 +155,7 @@ class CmdLineFwk:
             logger, `level` is a logging level name ('DEBUG', 'INFO', etc.)
         """
         if longlog:
-            message_fmt = "%-5p %d{yyyy-MM-ddThh:mm:ss.sss} %c (%X{LABEL})(%F:%L)- %m%n"
+            message_fmt = "%-5p %d{yyyy-MM-ddTHH:mm:ss.SSSZ} %c (%X{LABEL})(%F:%L)- %m%n"
         else:
             message_fmt = "%c %p: %m%n"
 


### PR DESCRIPTION
See https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html for format characters.