### PR TITLE
DM-21055: Protect against empty graph

### DIFF
--- a/python/lsst/ctrl/mpexec/examples/rawToCalexpTask.py
+++ b/python/lsst/ctrl/mpexec/examples/rawToCalexpTask.py
@@ -12,18 +12,18 @@ _LOG = logging.getLogger(__name__.partition(".")[2])
 
 class RawToCalexpTaskConfig(PipelineTaskConfig):
     input = InputDatasetField(name="raw",
-                              dimensions=["Instrument", "Exposure", "Detector"],
+                              dimensions=["instrument", "exposure", "detector"],
                               storageClass="ExposureU",
                               doc="Input dataset type for this task")
     output = OutputDatasetField(name="calexp",
-                                dimensions=["Instrument", "Visit", "Detector"],
+                                dimensions=["instrument", "visit", "detector"],
                                 storageClass="ExposureF",
                                 scalar=True,
                                 doc="Output dataset type for this task")
 
     def setDefaults(self):
         # set dimensions of a quantum, this task uses per-visit-detector quanta
-        self.quantum.dimensions = ["Instrument", "Visit", "Detector"]
+        self.quantum.dimensions = ["instrument", "visit", "detector"]
 
 
 class RawToCalexpTask(PipelineTask):


### PR DESCRIPTION
Adds logic to cmdLineFwk which avoids any actions on empty generated
graph. If graph is empty then `pipetask` will return immediately with
error code without saving anything to pickle or registry.