### PR TITLE
DM-20845: Support re-run of pipetask on the same output collection

### DIFF
--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -367,7 +367,9 @@ class CmdLineFwk:
                                         outputOverrides=outputs)
 
             # make execution plan (a.k.a. DAG) for pipeline
-            graphBuilder = GraphBuilder(taskFactory, butler.registry, args.skip_existing)
+            graphBuilder = GraphBuilder(taskFactory, butler.registry,
+                                        skipExisting=args.skip_existing,
+                                        clobberExisting=args.clobber_output)
             qgraph = graphBuilder.makeGraph(pipeline, coll, args.data_query)
 
         # count quanta in graph and give a warning if it's empty and return None
@@ -415,14 +417,15 @@ class CmdLineFwk:
         if not butler.run:
             raise ValueError("no output collection defined in data butler")
 
-        preExecInit = PreExecInit(butler, taskFactory, args.skip_existing)
+        preExecInit = PreExecInit(butler, taskFactory, args.skip_existing, args.clobber_output)
         preExecInit.initialize(graph,
                                saveInitOutputs=not args.skip_init_writes,
                                registerDatasetTypes=args.register_dataset_types)
 
         if not args.init_only:
             executor = MPGraphExecutor(numProc=args.processes, timeout=self.MP_TIMEOUT,
-                                       skipExisting=args.skip_existing)
+                                       skipExisting=args.skip_existing,
+                                       clobberOutput=args.clobber_output)
             with util.profile(args.profile, _LOG):
                 executor.execute(graph, butler, taskFactory)
 

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -388,7 +388,7 @@ class CmdLineFwk:
 
         return qgraph
 
-    def runPipeline(self, graph, taskFactory, args):
+    def runPipeline(self, graph, taskFactory, args, butler=None):
         """Execute complete QuantumGraph.
 
         Parameters
@@ -399,13 +399,17 @@ class CmdLineFwk:
             Task factory.
         args : `argparse.Namespace`
             Parsed command line
+        butler : `~lsst.daf.butler.Butler`, optional
+            Data Butler instance, if not defined then new instance is made
+            using command line options.
         """
         # If default output collection is given then use it to override
         # butler-configured one.
         run = args.output.get("", None)
 
         # make butler instance
-        butler = Butler(config=args.butler_config, run=run)
+        if butler is None:
+            butler = Butler(config=args.butler_config, run=run)
 
         # at this point we require that output collection was defined
         if not butler.run:

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -419,7 +419,8 @@ class CmdLineFwk:
 
         if not args.init_only:
             executor = MPGraphExecutor(numProc=args.processes, timeout=self.MP_TIMEOUT)
-            executor.execute(graph, butler, taskFactory)
+            with util.profile(args.profile, _LOG):
+                executor.execute(graph, butler, taskFactory)
 
     def showInfo(self, showOpts, pipeline, graph=None):
         """Display useful info about pipeline and environment.

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -415,14 +415,14 @@ class CmdLineFwk:
         if not butler.run:
             raise ValueError("no output collection defined in data butler")
 
-        preExecInit = PreExecInit(butler)
-        preExecInit.initialize(graph, taskFactory,
-                               registerDatasetTypes=args.register_dataset_types,
+        preExecInit = PreExecInit(butler, taskFactory, args.skip_existing)
+        preExecInit.initialize(graph,
                                saveInitOutputs=not args.skip_init_writes,
-                               updateOutputCollection=True)
+                               registerDatasetTypes=args.register_dataset_types)
 
         if not args.init_only:
-            executor = MPGraphExecutor(numProc=args.processes, timeout=self.MP_TIMEOUT)
+            executor = MPGraphExecutor(numProc=args.processes, timeout=self.MP_TIMEOUT,
+                                       skipExisting=args.skip_existing)
             with util.profile(args.profile, _LOG):
                 executor.execute(graph, butler, taskFactory)
 

--- a/python/lsst/ctrl/mpexec/cmdLineParser.py
+++ b/python/lsst/ctrl/mpexec/cmdLineParser.py
@@ -406,7 +406,7 @@ def makeParser(fromfile_prefix_chars='@', parser_class=ArgumentParser, **kwargs)
             subparser.add_argument("--skip-existing", dest="skip_existing",
                                    default=False, action="store_true",
                                    help="If all Quantum outputs already exist in output collection "
-                                   "then Qauntum will be excluded from QuantumGraph.")
+                                   "then Quantum will be excluded from QuantumGraph.")
         subparser.add_argument("-s", "--save-pipeline", dest="save_pipeline",
                                help="Location for storing a serialized pipeline definition (pickle file).",
                                metavar="PATH")

--- a/python/lsst/ctrl/mpexec/cmdLineParser.py
+++ b/python/lsst/ctrl/mpexec/cmdLineParser.py
@@ -403,10 +403,18 @@ def makeParser(fromfile_prefix_chars='@', parser_class=ArgumentParser, **kwargs)
                                "ordering is performed as last step before saving or executing "
                                "pipeline.")
         if subcommand in ("qgraph", "run"):
-            subparser.add_argument("--skip-existing", dest="skip_existing",
-                                   default=False, action="store_true",
-                                   help="If all Quantum outputs already exist in output collection "
-                                   "then Quantum will be excluded from QuantumGraph.")
+            group = subparser.add_mutually_exclusive_group()
+            group.add_argument("--skip-existing", dest="skip_existing",
+                               default=False, action="store_true",
+                               help="If all Quantum outputs already exist in output collection "
+                               "then Quantum will be excluded from QuantumGraph.")
+            group.add_argument("--clobber-output", dest="clobber_output",
+                               default=False, action="store_true",
+                               help="Ignore or replace existing output datasets in output collecton. "
+                               "With this option existing output datasets are ignored when generating "
+                               "QuantumGraph, and they are removed from a collection prior to "
+                               "executing individual Quanta. This option is exclusive with "
+                               "--skip-existing option.")
         subparser.add_argument("-s", "--save-pipeline", dest="save_pipeline",
                                help="Location for storing a serialized pipeline definition (pickle file).",
                                metavar="PATH")

--- a/python/lsst/ctrl/mpexec/examples/make_example_qgraph.py
+++ b/python/lsst/ctrl/mpexec/examples/make_example_qgraph.py
@@ -17,8 +17,7 @@ import sys
 #  Imports for other modules --
 # -----------------------------
 from lsst.daf.butler import DatasetRef, Quantum, Run
-from lsst.pipe.base import DatasetTypeDescriptor
-from lsst.pipe.base import Pipeline, QuantumGraph, QuantumGraphTaskNodes, TaskDef
+from lsst.pipe.base import Pipeline, QuantumGraph, QuantumGraphTaskNodes, TaskDatasetTypes, TaskDef
 from lsst.pipe.base.pipeTools import orderPipeline
 from lsst.ctrl.mpexec.dotTools import graph2dot, pipeline2dot
 from lsst.ctrl.mpexec.examples import test1task, test2task
@@ -96,17 +95,16 @@ def main():
         step2 = _makeStep2TaskDef()
         step3 = _makeStep3TaskDef()
 
-        dstype0 = DatasetTypeDescriptor.fromConfig(step1.config.input).datasetType
-        dstype1 = DatasetTypeDescriptor.fromConfig(step1.config.output).datasetType
-        dstype2 = DatasetTypeDescriptor.fromConfig(step2.config.output).datasetType
-        dstype3 = DatasetTypeDescriptor.fromConfig(step3.config.output).datasetType
+        dstypes1 = TaskDatasetTypes.fromConnections(step1.connections)
+        dstypes2 = TaskDatasetTypes.fromConnections(step2.connections)
+        dstypes3 = TaskDatasetTypes.fromConnections(step3.connections)
 
         # quanta for first step which is 1-to-1 tasks
         quanta = []
         for visit in range(10):
             quantum = Quantum(run=run, task=None)
-            quantum.addPredictedInput(_makeDSRefVisit(dstype0, visit))
-            quantum.addOutput(_makeDSRefVisit(dstype1, visit))
+            quantum.addPredictedInput(_makeDSRefVisit(dstypes1.inputs[0], visit))
+            quantum.addOutput(_makeDSRefVisit(dstypes1.outputs[0], visit))
             quanta.append(quantum)
         step1nodes = QuantumGraphTaskNodes(step1, quanta)
 
@@ -114,8 +112,8 @@ def main():
         quanta = []
         for visit in range(10):
             quantum = Quantum(run=run, task=None)
-            quantum.addPredictedInput(_makeDSRefVisit(dstype1, visit))
-            quantum.addOutput(_makeDSRefVisit(dstype2, visit))
+            quantum.addPredictedInput(_makeDSRefVisit(dstypes2.inputs[0], visit))
+            quantum.addOutput(_makeDSRefVisit(dstypes2.outputs[0], visit))
             quanta.append(quantum)
         step2nodes = QuantumGraphTaskNodes(step2, quanta)
 
@@ -130,8 +128,8 @@ def main():
         for tract, patch, visits in patch2visits:
             quantum = Quantum(run=run, task=None)
             for visit in visits:
-                quantum.addPredictedInput(_makeDSRefVisit(dstype2, visit))
-            quantum.addOutput(_makeDSRefPatch(dstype3, tract, patch))
+                quantum.addPredictedInput(_makeDSRefVisit(dstypes3.inputs[0], visit))
+            quantum.addOutput(_makeDSRefPatch(dstypes3.outputs[0], tract, patch))
             quanta.append(quantum)
         step3nodes = QuantumGraphTaskNodes(step3, quanta)
 

--- a/python/lsst/ctrl/mpexec/examples/patchSkyMapTask.py
+++ b/python/lsst/ctrl/mpexec/examples/patchSkyMapTask.py
@@ -4,32 +4,32 @@
 import logging
 
 from lsst.pipe.base import (Struct, PipelineTask, PipelineTaskConfig,
-                            InputDatasetField, OutputDatasetField)
+                            PipelineTaskConnections)
+from lsst.pipe.base import connectionTypes as cT
 
 _LOG = logging.getLogger(__name__.partition(".")[2])
 
 
-class PatchSkyMapTaskConfig(PipelineTaskConfig):
-    coadd = InputDatasetField(name="deepCoadd_calexp",
-                              dimensions=["SkyMap", "Tract", "Patch", "AbstractFilter"],
-                              storageClass="ExposureF",
-                              scalar=True,
-                              doc="DatasetType for the input image")
-    inputCatalog = InputDatasetField(name="deepCoadd_mergeDet",
-                                     dimensions=["SkyMap", "Tract", "Patch"],
-                                     storageClass="SourceCatalog",
-                                     scalar=True,
-                                     doc="DatasetType for the input catalog (merged detections).")
-    outputCatalog = OutputDatasetField(name="deepCoadd_meas",
-                                       dimensions=["SkyMap", "Tract", "Patch", "AbstractFilter"],
-                                       storageClass="SourceCatalog",
-                                       scalar=True,
-                                       doc=("DatasetType for the output catalog "
-                                            "(deblended per-band measurements)"))
+class PatchSkyMapTaskConnections(PipelineTaskConnections,
+                                 dimensions=("skymap", "tract", "patch", "abstract_filter")):
+    coadd = cT.Input(name="deepCoadd_calexp",
+                     dimensions=["skymap", "tract", "patch", "abstract_filter"],
+                     storageClass="ExposureF",
+                     doc="DatasetType for the input image")
+    inputCatalog = cT.Input(name="deepCoadd_mergeDet",
+                            dimensions=["skymap", "tract", "patch"],
+                            storageClass="SourceCatalog",
+                            doc="DatasetType for the input catalog (merged detections).")
+    outputCatalog = cT.Output(name="deepCoadd_meas",
+                              dimensions=["skymap", "tract", "patch", "abstract_filter"],
+                              storageClass="SourceCatalog",
+                              doc=("DatasetType for the output catalog "
+                                   "(deblended per-band measurements)"))
 
-    def setDefaults(self):
-        # set dimensions of a quantum, this task uses per-tract-patch-filter quanta
-        self.quantum.dimensions = ["SkyMap", "Tract", "Patch", "AbstractFilter"]
+
+class PatchSkyMapTaskConfig(PipelineTaskConfig,
+                            pipelineConnections=PatchSkyMapTaskConnections):
+    pass
 
 
 class PatchSkyMapTask(PipelineTask):

--- a/python/lsst/ctrl/mpexec/examples/rawToCalexpTask.py
+++ b/python/lsst/ctrl/mpexec/examples/rawToCalexpTask.py
@@ -5,25 +5,28 @@ import logging
 
 from lsst.afw.image import ExposureF
 from lsst.pipe.base import (Struct, PipelineTask, PipelineTaskConfig,
-                            InputDatasetField, OutputDatasetField)
+                            PipelineTaskConnections)
+from lsst.pipe.base import connectionTypes as cT
 
 _LOG = logging.getLogger(__name__.partition(".")[2])
 
 
-class RawToCalexpTaskConfig(PipelineTaskConfig):
-    input = InputDatasetField(name="raw",
-                              dimensions=["instrument", "exposure", "detector"],
-                              storageClass="ExposureU",
-                              doc="Input dataset type for this task")
-    output = OutputDatasetField(name="calexp",
-                                dimensions=["instrument", "visit", "detector"],
-                                storageClass="ExposureF",
-                                scalar=True,
-                                doc="Output dataset type for this task")
+class RawToCalexpTaskConnections(PipelineTaskConnections,
+                                 dimensions=("instrument", "visit", "detector")):
+    input = cT.Input(name="raw",
+                     dimensions=["instrument", "exposure", "detector"],
+                     multiple=True,
+                     storageClass="Exposure",
+                     doc="Input dataset type for this task")
+    output = cT.Output(name="calexp",
+                       dimensions=["instrument", "visit", "detector"],
+                       storageClass="ExposureF",
+                       doc="Output dataset type for this task")
 
-    def setDefaults(self):
-        # set dimensions of a quantum, this task uses per-visit-detector quanta
-        self.quantum.dimensions = ["instrument", "visit", "detector"]
+
+class RawToCalexpTaskConfig(PipelineTaskConfig,
+                            pipelineConnections=RawToCalexpTaskConnections):
+    pass
 
 
 class RawToCalexpTask(PipelineTask):

--- a/python/lsst/ctrl/mpexec/examples/test1task.py
+++ b/python/lsst/ctrl/mpexec/examples/test1task.py
@@ -7,27 +7,26 @@ building Pipeline or QuantumGraph.
 import logging
 
 from lsst.pipe.base import (Struct, PipelineTask, PipelineTaskConfig,
-                            InputDatasetField, OutputDatasetField)
+                            PipelineTaskConnections)
+from lsst.pipe.base import connectionTypes as cT
 
 _LOG = logging.getLogger(__name__.partition(".")[2])
 
 
-class Test1Config(PipelineTaskConfig):
-    input = InputDatasetField(name="input",
-                              dimensions=["Instrument", "Visit"],
-                              storageClass="example",
-                              scalar=True,
-                              doc="Input dataset type for this task")
-    output = OutputDatasetField(name="output",
-                                dimensions=["Instrument", "Visit"],
-                                storageClass="example",
-                                scalar=True,
-                                doc="Output dataset type for this task")
+class Test1Connections(PipelineTaskConnections,
+                       dimensions=("instrument", "visit")):
+    input = cT.Input(name="input",
+                     dimensions=["instrument", "visit"],
+                     storageClass="example",
+                     doc="Input dataset type for this task")
+    output = cT.Output(name="output",
+                       dimensions=["instrument", "visit"],
+                       storageClass="example",
+                       doc="Output dataset type for this task")
 
-    def setDefaults(self):
-        # set dimensions of a quantum, this task uses per-visit quanta and it
-        # expects datset dimensions to be the same
-        self.quantum.dimensions = ["Instrument", "Visit"]
+
+class Test1Config(PipelineTaskConfig, pipelineConnections=Test1Connections):
+    pass
 
 
 class Test1Task(PipelineTask):

--- a/python/lsst/ctrl/mpexec/examples/test2task.py
+++ b/python/lsst/ctrl/mpexec/examples/test2task.py
@@ -7,27 +7,27 @@ building Pipeline or QuantumGraph.
 import logging
 
 from lsst.pipe.base import (Struct, PipelineTask, PipelineTaskConfig,
-                            InputDatasetField, OutputDatasetField)
+                            PipelineTaskConnections)
+from lsst.pipe.base import connectionTypes as cT
 
 _LOG = logging.getLogger(__name__.partition(".")[2])
 
 
-class Test2Config(PipelineTaskConfig):
-    input = InputDatasetField(name="input",
-                              dimensions=["Instrument", "Visit"],
-                              storageClass="example",
-                              doc="Input dataset type for this task")
-    output = OutputDatasetField(name="output",
-                                dimensions=["Tract", "Patch"],
-                                storageClass="example",
-                                scalar=True,
-                                doc="Output dataset type for this task")
+class Test2Connections(PipelineTaskConnections,
+                       dimensions=("instrument", "tract", "patch")):
+    input = cT.Input(name="input",
+                     dimensions=["instrument", "visit"],
+                     multiple=True,
+                     storageClass="example",
+                     doc="Input dataset type for this task")
+    output = cT.Output(name="output",
+                       dimensions=["tract", "patch"],
+                       storageClass="example",
+                       doc="Output dataset type for this task")
 
-    def setDefaults(self):
-        # this task combines all selected visits into a tract/patch, on
-        # input it expects per-visit data, on output it produces per-patch.
-        # Combining visits "destroys" Visit dimension in a quantum.
-        self.quantum.dimensions = ["Instrument", "Tract", "Patch"]
+
+class Test2Config(PipelineTaskConfig, pipelineConnections=Test2Connections):
+    pass
 
 
 class Test2Task(PipelineTask):

--- a/python/lsst/ctrl/mpexec/mpGraphExecutor.py
+++ b/python/lsst/ctrl/mpexec/mpGraphExecutor.py
@@ -88,8 +88,10 @@ class MPGraphExecutor(QuantumGraphExecutor):
         for qdata in iterable:
             _LOG.debug("Executing %s", qdata)
             taskDef = qdata.taskDef
-            self._executePipelineTask(taskDef.taskClass, taskDef.config, qdata.quantum,
-                                      butler, taskFactory, self.skipExisting, self.clobberOutput)
+            self._executePipelineTask(taskClass=taskDef.taskClass, config=taskDef.config,
+                                      quantum=qdata.quantum, butler=butler,
+                                      taskFactory=taskFactory, skipExisting=self.skipExisting,
+                                      clobberOutput=self.clobberOutput)
 
     def _executeQuantaMP(self, iterable, butler, taskFactory):
         """Execute all Quanta in separate process pool.
@@ -133,9 +135,10 @@ class MPGraphExecutor(QuantumGraphExecutor):
 
             # Add it to the pool and remember its result
             _LOG.debug("Sumbitting %s", qdata)
-            args = (taskDef.taskClass, taskDef.config, qdata.quantum, butler, taskFactory,
-                    self.skipExisting, self.clobberOutput)
-            results[qdata.index] = pool.apply_async(self._executePipelineTask, args)
+            kwargs = dict(taskClass=taskDef.taskClass, config=taskDef.config,
+                          quantum=qdata.quantum, butler=butler, taskFactory=taskFactory,
+                          skipExisting=self.skipExisting, clobberOutput=self.clobberOutput)
+            results[qdata.index] = pool.apply_async(self._executePipelineTask, (), kwargs)
 
         # Everything is submitted, wait until it's complete
         _LOG.debug("Wait for all tasks")
@@ -147,7 +150,7 @@ class MPGraphExecutor(QuantumGraphExecutor):
                 res.get(self.timeout)
 
     @staticmethod
-    def _executePipelineTask(taskClass, config, quantum, butler, taskFactory, skipExisting, clobberOutput):
+    def _executePipelineTask(*, taskClass, config, quantum, butler, taskFactory, skipExisting, clobberOutput):
         """Execute PipelineTask on a single data item.
 
         Parameters

--- a/python/lsst/ctrl/mpexec/preExecInit.py
+++ b/python/lsst/ctrl/mpexec/preExecInit.py
@@ -45,12 +45,19 @@ class PreExecInit:
     ----------
     butler : `~lsst.daf.butler.Butler`
         Data butler instance.
+    taskFactory : `~lsst.pipe.base.TaskFactory`
+        Task factory.
+    skipExisting : `bool`, optional
+        If `True` then do not try to overwrite any datasets that might exist
+        in the butler. If `False` then any existing conflicting dataset will
+        cause butler exception.
     """
-    def __init__(self, butler):
+    def __init__(self, butler, taskFactory, skipExisting=False):
         self.butler = butler
+        self.taskFactory = taskFactory
+        self.skipExisting = skipExisting
 
-    def initialize(self, graph, taskFactory, registerDatasetTypes=False,
-                   saveInitOutputs=True, updateOutputCollection=True):
+    def initialize(self, graph, saveInitOutputs=True, registerDatasetTypes=False):
         """Perform all initialization steps.
 
         Convenience method to execute all initialization steps. Instead of
@@ -61,30 +68,22 @@ class PreExecInit:
         ----------
         graph : `~lsst.pipe.base.QuantumGraph`
             Execution graph.
-        taskFactory : `~lsst.pipe.base.TaskFactory`
-            Task factory.
+        saveInitOutputs : `bool`, optional
+            If ``True`` (default) then save task "init outputs" to butler.
         registerDatasetTypes : `bool`, optional
             If ``True`` then register dataset types in registry, otherwise
             they must be already registered.
-        saveInitOutputs : `bool`, optional
-            If ``True`` (default) then save task "init outputs" to butler.
-        updateOutputCollection : `bool`, optional
-            If ``True`` (default) then copy all inputs to output collection.
         """
         # register dataset types or check consistency
         self.initializeDatasetTypes(graph, registerDatasetTypes)
 
         # associate all existing datasets with output collection.
-        if updateOutputCollection:
-            self.updateOutputCollection(graph)
+        self.updateOutputCollection(graph)
 
-        # Save task initialization data.
-        # TODO: see if Pipeline and software versions are already written
-        # to butler and associated with Run, check for consistency if they
-        # are, and if so skip writing TaskInitOutputs (because those should
-        # also only be done once).  If not, write them.
+        # Save task initialization data or check that saved data
+        # is consistent with what tasks would save
         if saveInitOutputs:
-            self.saveInitOutputs(graph, taskFactory)
+            self.saveInitOutputs(graph)
 
     def initializeDatasetTypes(self, graph, registerDatasetTypes=False):
         """Save or check DatasetTypes output by the tasks in a graph.
@@ -147,6 +146,9 @@ class PreExecInit:
                 yield ref
                 yield from _refComponents(ref.components.values())
 
+        collection = self.butler.run.collection
+        registry = self.butler.registry
+
         # Main issue here is that the same DataRef can appear as input for
         # many quanta, to keep them unique we first collect them into one
         # dict indexed by dataset id.
@@ -159,30 +161,69 @@ class PreExecInit:
                         id2ref[ref.id] = ref
         for initInput in graph.initInputs.values():
             id2ref[initInput.id] = initInput
-        _LOG.debug("Associating %d datasets with output collection %s",
-                   len(id2ref), self.butler.run.collection)
-        if id2ref:
-            # copy all collected refs to output collection
-            collection = self.butler.run.collection
-            registry = self.butler.registry
-            registry.associate(collection, list(id2ref.values()))
 
-    def saveInitOutputs(self, graph, taskFactory):
+        _LOG.debug("Associating %d datasets with output collection %s", len(id2ref), collection)
+
+        refs = []
+        if not self.skipExisting:
+            # optimization - save all at once, butler will raise an exception
+            # if any dataset is already there
+            refs = list(id2ref.values())
+        else:
+            # skip existing ones
+            for ref in id2ref.values():
+                if registry.find(collection, ref.datasetType, ref.dataId) is None:
+                    refs.append(ref)
+        if refs:
+            registry.associate(collection, refs)
+
+    def saveInitOutputs(self, graph):
         """Write any datasets produced by initializing tasks in a graph.
 
         Parameters
         ----------
         graph : `~lsst.pipe.base.QuantumGraph`
             Execution graph.
-        taskFactory : `~lsst.pipe.base.TaskFactory`
-            Task factory.
+
+        Raises
+        ------
+        Exception
+            Raised if ``skipExisting`` is `False` and datasets already
+            exists. Content of a butler collection may be changed if
+            exception is raised.
+
+        Note
+        ----
+        If ``skipExisting`` is `True` then existing datasets are not
+        overwritten, instead we should check that their stored object is
+        exactly the same as what we would save at this time. Comparing
+        arbitrary types of object is, of course, non-trivial. Current
+        implementation only checks the existence of the datasets and their
+        types against the types of objects produced by tasks. Ideally we
+        would like to check that object data is identical too but presently
+        there is no generic way to compare objects. In the future we can
+        potentially introduce some extensible mechanism for that.
         """
         _LOG.debug("Will save InitOutputs for all tasks")
         for taskNodes in graph:
             taskDef = taskNodes.taskDef
-            task = taskFactory.makeTask(taskDef.taskClass, taskDef.config, None, self.butler)
+            task = self.taskFactory.makeTask(taskDef.taskClass, taskDef.config, None, self.butler)
             for name in taskDef.connections.initOutputs:
                 attribute = getattr(taskDef.connections, name)
                 initOutputVar = getattr(task, name)
-                _LOG.debug("Saving InitOutputs for task=%s key=%s", task, name)
-                self.butler.put(initOutputVar, attribute.name, {})
+                objFromStore = None
+                if self.skipExisting:
+                    # check if it is there already
+                    _LOG.debug("Retrieving InitOutputs for task=%s key=%s dsTypeName=%s",
+                               task, name, attribute.name)
+                    objFromStore = self.butler.get(attribute.name, {})
+                    if objFromStore is not None:
+                        # types are supposed to be identical
+                        if type(objFromStore) is not type(initOutputVar):
+                            raise TypeError(f"Stored initOutput object type {type(objFromStore)} "
+                                            f"is different  from task-generated type "
+                                            f"{type(initOutputVar)} for task {taskDef}")
+                if objFromStore is None:
+                    # butler will raise exception if dataset is already there
+                    _LOG.debug("Saving InitOutputs for task=%s key=%s", task, name)
+                    self.butler.put(initOutputVar, attribute.name, {})

--- a/python/lsst/ctrl/mpexec/util.py
+++ b/python/lsst/ctrl/mpexec/util.py
@@ -22,13 +22,12 @@
 """Few utility methods used by the rest of a package.
 """
 
-__all__ = ["profile", "printTable", "fixPath", "filterTasks", "subTaskIter"]
+__all__ = ["profile", "printTable", "filterTasks", "subTaskIter"]
 
 # -------------------------------
 #  Imports of standard modules --
 # -------------------------------
 import contextlib
-import os
 
 # -----------------------------
 #  Imports for other modules --
@@ -99,24 +98,6 @@ def printTable(rows, header):
         print("".ljust(width, "-"), "".ljust(len(header[1]), "-"))
     for col1, col2 in rows:
         print(col1.ljust(width), col2)
-
-
-def fixPath(defName, path):
-    """!Apply environment variable as default root, if present, and abspath
-
-    @param[in] defName  name of environment variable containing default root path;
-        if the environment variable does not exist then the path is relative
-        to the current working directory
-    @param[in] path     path relative to default root path
-    @return abspath: path that has been expanded, or None if the environment variable does not exist
-        and path is None
-    """
-    defRoot = os.environ.get(defName)
-    if defRoot is None:
-        if path is None:
-            return None
-        return os.path.abspath(path)
-    return os.path.abspath(os.path.join(defRoot, path or ""))
 
 
 def filterTasks(pipeline, name):

--- a/tests/config/butler.yaml
+++ b/tests/config/butler.yaml
@@ -1,0 +1,1 @@
+run: ctrl_mpexec_tests

--- a/tests/testUtil.py
+++ b/tests/testUtil.py
@@ -1,0 +1,241 @@
+# This file is part of ctrl_mpexec.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Bunch of common classes and methods for use in unit tests.
+"""
+
+__all__ = ["AddTaskConfig", "AddTask", "AddTaskFactoryMock", "ButlerMock"]
+
+import itertools
+import logging
+import numpy
+import os
+from types import SimpleNamespace
+
+from lsst.daf.butler import (ButlerConfig, DatasetRef, DimensionUniverse,
+                             DatasetType, Registry, Run, DatasetOriginInfoDef)
+import lsst.pex.config as pexConfig
+import lsst.pipe.base as pipeBase
+from lsst.pipe.base import connectionTypes as cT
+
+_LOG = logging.getLogger(__name__)
+
+
+class AddTaskConnections(pipeBase.PipelineTaskConnections,
+                         dimensions=("instrument", "detector")):
+    input = cT.Input(name="add_input",
+                     dimensions=["instrument", "detector"],
+                     storageClass="NumpyArray",
+                     doc="Input dataset type for this task")
+    output = cT.Output(name="add_output",
+                       dimensions=["instrument", "detector"],
+                       storageClass="NumpyArray",
+                       doc="Output dataset type for this task")
+    initout = cT.InitOutput(name="add_init_output",
+                            storageClass="NumpyArray",
+                            doc="Init Output dataset type for this task")
+
+
+class AddTaskConfig(pipeBase.PipelineTaskConfig,
+                    pipelineConnections=AddTaskConnections):
+    addend = pexConfig.Field(doc="amount to add", dtype=int, default=3)
+
+
+# example task which overrides run() method
+class AddTask(pipeBase.PipelineTask):
+    ConfigClass = AddTaskConfig
+    _DefaultName = "add_task"
+
+    initout = numpy.array([999])
+    """InitOutputs for this task"""
+
+    countExec = 0
+    """Number of times run() method was called for this class"""
+
+    def run(self, input):
+        AddTask.countExec += 1
+        self.metadata.add("add", self.config.addend)
+        output = [val + self.config.addend for val in input]
+        _LOG.info("input = %s, output = %s", input, output)
+        return pipeBase.Struct(output=output)
+
+
+class AddTaskFactoryMock(pipeBase.TaskFactory):
+    def loadTaskClass(self, taskName):
+        if taskName == "AddTask":
+            return AddTask, "AddTask"
+
+    def makeTask(self, taskClass, config, overrides, butler):
+        if config is None:
+            config = taskClass.ConfigClass()
+            if overrides:
+                overrides.applyTo(config)
+        return taskClass(config=config, initInputs=None)
+
+
+class ButlerMock:
+    """Mock version of butler, only usable for testing
+
+    Parameters
+    ----------
+    fullRegistry : `boolean`, optional
+        If True then instantiate SQLite registry with default configuration.
+        If False then registry is just a namespace with `dimensions` attribute
+        containing DimensionUniverse from default configuration.
+    """
+    def __init__(self, fullRegistry=False, collection="TestColl"):
+        self.datasets = {}
+        self.fullRegistry = fullRegistry
+        if self.fullRegistry:
+            testDir = os.path.dirname(__file__)
+            configFile = os.path.join(testDir, "config/butler.yaml")
+            butlerConfig = ButlerConfig(configFile)
+            self.registry = Registry.fromConfig(butlerConfig, create=True)
+            self.run = self.registry.makeRun(collection)
+        else:
+            self.registry = SimpleNamespace(dimensions=DimensionUniverse.fromConfig())
+            self.run = Run(collection=collection, environment=None, pipeline=None)
+
+    def _standardizeArgs(self, datasetRefOrType, dataId=None, **kwds):
+        """Copied from real Butler
+        """
+        if isinstance(datasetRefOrType, DatasetRef):
+            if dataId is not None or kwds:
+                raise ValueError("DatasetRef given, cannot use dataId as well")
+            datasetType = datasetRefOrType.datasetType
+            dataId = datasetRefOrType.dataId
+        else:
+            # Don't check whether DataId is provided, because Registry APIs
+            # can usually construct a better error message when it wasn't.
+            if isinstance(datasetRefOrType, DatasetType):
+                datasetType = datasetRefOrType
+            else:
+                datasetType = self.registry.getDatasetType(datasetRefOrType)
+        return datasetType, dataId
+
+    @staticmethod
+    def key(dataId):
+        """Make a dict key out of dataId.
+        """
+        return frozenset(dataId.items())
+
+    def get(self, datasetRefOrType, dataId=None, parameters=None, **kwds):
+        datasetType, dataId = self._standardizeArgs(datasetRefOrType, dataId, **kwds)
+        _LOG.info("butler.get: datasetType=%s dataId=%s", datasetType.name, dataId)
+        dsTypeName = datasetType.name
+        key = self.key(dataId)
+        dsdata = self.datasets.get(dsTypeName)
+        if dsdata:
+            return dsdata.get(key)
+        return None
+
+    def put(self, obj, datasetRefOrType, dataId=None, producer=None, **kwds):
+        datasetType, dataId = self._standardizeArgs(datasetRefOrType, dataId, **kwds)
+        _LOG.info("butler.put: datasetType=%s dataId=%s obj=%r", datasetType.name, dataId, obj)
+        dsTypeName = datasetType.name
+        key = self.key(dataId)
+        dsdata = self.datasets.setdefault(dsTypeName, {})
+        dsdata[key] = obj
+        if self.fullRegistry:
+            ref = self.registry.addDataset(datasetType, dataId, run=self.run, producer=producer,
+                                           recursive=False, **kwds)
+        else:
+            # we should return DatasetRef with reasonable ID, ID is supposed to be unique
+            refId = sum(len(val) for val in self.datasets.values())
+            ref = DatasetRef(datasetType, dataId, id=refId)
+        return ref
+
+
+def registerDatasetTypes(registry, pipeline):
+    """Register all dataset types used by tasks in a registry.
+
+    Copied and modified from `PreExecInit.initializeDatasetTypes`.
+
+    Parameters
+    ----------
+    registry : `~lsst.daf.butler.Registry`
+        Registry instance.
+    pipeline : `~lsst.pipe.base.Pipeline`
+        Iterable of TaskDef instances.
+    """
+    for taskDef in pipeline:
+        datasetTypes = pipeBase.TaskDatasetTypes.fromConnections(taskDef.connections,
+                                                                 universe=registry.dimensions)
+        for datasetType in itertools.chain(datasetTypes.initInputs, datasetTypes.initOutputs,
+                                           datasetTypes.inputs, datasetTypes.outputs,
+                                           datasetTypes.prerequisites):
+            _LOG.info("Registering %s with registry", datasetType)
+            # this is a no-op if it already exists and is consistent,
+            # and it raises if it is inconsistent.
+            registry.registerDatasetType(datasetType)
+
+
+def makeSimpleQGraph(nQuanta=5, pipeline=None):
+    """Make simple QuantumGraph for tests.
+
+    Makes simple one-task pipeline with AddTask, sets up in-memory
+    registry and butler, fills them with minimal data, and generates
+    QuantumGraph with all of that.
+
+    Parameters
+    ----------
+    nQuanta : `int`
+        Number of quanta in a graph.
+    pipeline : `~lsst.pipe.base.Pipeline`
+        If `None` then one-task pipeline is made with `AddTask` and
+        default `AddTaskConfig`.
+
+    Returns
+    -------
+    butler : `~lsst.daf.butler.Butler`
+        Butler instance
+    qgraph : `~lsst.pipe.base.QuantumGraph`
+        Quantum graph instance
+    """
+
+    butler = ButlerMock(fullRegistry=True)
+
+    if pipeline is None:
+        taskDef = pipeBase.TaskDef("AddTask", AddTaskConfig(), taskClass=AddTask, label="task1")
+        pipeline = pipeBase.Pipeline([taskDef])
+
+    # Add dataset types to registry
+    registerDatasetTypes(butler.registry, pipeline)
+
+    # Small set of DataIds included in QGraph
+    dataIds = [dict(instrument="INSTR", detector=detector) for detector in range(nQuanta)]
+
+    # Add all needed dimensions to registry
+    butler.registry.addDimensionEntry("instrument", dict(instrument="INSTR"))
+    butler.registry.addDimensionEntryList("detector", dataIds)
+
+    # Add inputs to butler, inputs a simply integers, remeber their refs
+    inputRefs = []
+    for i, dataId in enumerate(dataIds):
+        data = numpy.array([i, 10*i])
+        inputRefs.append(butler.put(data, "add_input", dataId))
+
+    # Make the graph, task factory is not needed here
+    builder = pipeBase.GraphBuilder(taskFactory=None, registry=butler.registry)
+    originInfo = DatasetOriginInfoDef([butler.run.collection], butler.run.collection)
+    qgraph = builder.makeGraph(pipeline, originInfo, "")
+
+    return butler, qgraph

--- a/tests/testUtil.py
+++ b/tests/testUtil.py
@@ -70,7 +70,12 @@ class AddTask(pipeBase.PipelineTask):
     countExec = 0
     """Number of times run() method was called for this class"""
 
+    stopAt = -1
+    """Raises exception at this call to run()"""
+
     def run(self, input):
+        if AddTask.stopAt == AddTask.countExec:
+            raise RuntimeError("pretend something bad happened")
         AddTask.countExec += 1
         self.metadata.add("add", self.config.addend)
         output = [val + self.config.addend for val in input]

--- a/tests/test_cmdLineFwk.py
+++ b/tests/test_cmdLineFwk.py
@@ -131,6 +131,7 @@ def _makeArgs(pipeline=None, qgraph=None, pipeline_actions=(), order_pipeline=Fa
     args.register_dataset_types = False
     args.skip_init_writes = False
     args.skip_existing = False
+    args.clobber_output = False
     args.init_only = False
     args.processes = 1
     args.profile = None
@@ -293,6 +294,37 @@ class CmdLineFwkTestCase(unittest.TestCase):
         args.skip_existing = True
         fwk.runPipeline(qgraph, taskFactory, args, butler=butler)
         self.assertEqual(AddTask.countExec, nQuanta)
+
+    def testSimpleQGraphClobberOutput(self):
+        """Test re-execution of trivial quantum graph with --clobber-output.
+        """
+
+        nQuanta = 5
+        butler, qgraph = makeSimpleQGraph(nQuanta)
+
+        # should have one task and number of quanta
+        self.assertEqual(len(qgraph), 1)
+        self.assertEqual(qgraph.countQuanta(), nQuanta)
+
+        args = _makeArgs()
+        fwk = CmdLineFwk()
+        taskFactory = AddTaskFactoryMock()
+
+        # run whole thing
+        AddTask.stopAt = -1
+        AddTask.countExec = 0
+        fwk.runPipeline(qgraph, taskFactory, args, butler=butler)
+        self.assertEqual(AddTask.countExec, nQuanta)
+
+        # and repeat
+        args.clobber_output = True
+        fwk.runPipeline(qgraph, taskFactory, args, butler=butler)
+        self.assertEqual(AddTask.countExec, 2*nQuanta)
+
+        # rebuild graph with clobber option, should make same graph
+        butler, qgraph = makeSimpleQGraph(nQuanta, butler=butler, clobberExisting=True)
+        self.assertEqual(len(qgraph), 1)
+        self.assertEqual(qgraph.countQuanta(), nQuanta)
 
 
 class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_cmdLineParser.py
+++ b/tests/test_cmdLineParser.py
@@ -193,7 +193,8 @@ class CmdLineParserTestCase(unittest.TestCase):
             """.split())
         qgraph_options = ['pipeline_actions', 'show', 'subparser', 'pipeline',
                           'order_pipeline', 'save_pipeline', 'pipeline_dot',
-                          'qgraph_dot', 'qgraph', 'save_qgraph', 'skip_existing']
+                          'qgraph_dot', 'qgraph', 'save_qgraph', 'skip_existing',
+                          'clobber_output']
         self.assertEqual(set(vars(args).keys()), set(global_options + qgraph_options))
         self.assertEqual(args.subcommand, 'qgraph')
 
@@ -204,7 +205,8 @@ class CmdLineParserTestCase(unittest.TestCase):
         run_options = ['pipeline_actions', 'show', 'subparser', 'pipeline',
                        'order_pipeline', 'save_pipeline', 'pipeline_dot',
                        'qgraph_dot', 'qgraph', 'save_qgraph', 'skip_existing',
-                       'register_dataset_types', 'skip_init_writes', 'init_only']
+                       'clobber_output', 'register_dataset_types', 'skip_init_writes',
+                       'init_only']
         self.assertEqual(set(vars(args).keys()), set(global_options + run_options))
         self.assertEqual(args.subcommand, 'run')
 
@@ -367,6 +369,10 @@ class CmdLineParserTestCase(unittest.TestCase):
         self.assertEqual(args.save_qgraph, "newqgraph.pickle")
         self.assertEqual(args.pipeline_dot, "pipe.dot")
         self.assertEqual(args.qgraph_dot, "qgraph.dot")
+
+        # check that exclusive options generate error
+        with self.assertRaises(_Error):
+            parser.parse_args("qgraph -p pipeline.pickle --skip-existing --clobber-output".split())
 
     def testCmdLinePipeline(self):
 

--- a/tests/test_cmdLineParser.py
+++ b/tests/test_cmdLineParser.py
@@ -289,6 +289,7 @@ class CmdLineParserTestCase(unittest.TestCase):
             -C label:filename1
             -c label:c=d -c label:e=f
             -C label:filename2 -C label:filename3
+            --skip-existing
             """.split())
         self.assertTrue(args.clobberConfig)
         self.assertTrue(args.clobberVersions)
@@ -318,8 +319,9 @@ class CmdLineParserTestCase(unittest.TestCase):
         self.assertIsNone(args.save_qgraph)
         self.assertIsNone(args.pipeline_dot)
         self.assertIsNone(args.qgraph_dot)
+        self.assertTrue(args.skip_existing)
 
-        # multiple tasks pluse more options (-q should be exclusive with
+        # multiple tasks plus more options (-q should be exclusive with
         # some other options but we do not check it during parsing (yet))
         args = parser.parse_args(
             """


### PR DESCRIPTION
With `--skip-existing` option we now also support skipping Quanta at run time so that the same QGraph can be executed again after unfinished previous attempt and it will effectively restart execution from the point where it stopped previously. Just as before `--skip-existing` during QGraph generation means skipping Quanta whose outputs already exist.

New option `--clobber-output` can be used to override datasets that exist in output collection:
- when generating QGraph all existing outputs are ignored (including regular outputs and initOutputs),
- when executing QGraph the existing outputs are removed prior to Quantum execution.
