### PR TITLE
Fix un-pickling of qgraph (DM-21724).

### DIFF
--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -331,6 +331,13 @@ class CmdLineFwk:
         """
         if args.qgraph:
 
+            # Un-pickling QGraph needs a dimensions universe defined in
+            # registry. Easiest way to do it now is to initialize whole data
+            # butler. Butler requires run or collection provided in
+            # constructor but in this case we do not care about (or do not
+            # know) what collection to use so give it an empty name.
+            butler = Butler(config=args.butler_config, collection="")
+
             with open(args.qgraph, 'rb') as pickleFile:
                 qgraph = pickle.load(pickleFile)
                 if not isinstance(qgraph, QuantumGraph):

--- a/tests/test_cmdLineFwk.py
+++ b/tests/test_cmdLineFwk.py
@@ -119,6 +119,7 @@ def _makeArgs(pipeline=None, qgraph=None, pipeline_actions=(), order_pipeline=Fa
         Name of the DOT file to write QGrpah representation.
     """
     args = argparse.Namespace()
+    args.butler_config = None
     args.pipeline = pipeline
     args.qgraph = qgraph
     args.pipeline_actions = pipeline_actions


### PR DESCRIPTION
Un-pickling of QGraph requires dimension universe to be initialized,
this patch instantiates data butler to initialize registry for that
effect.