### PR TITLE
DM-22177: ctrl_mpexec calls non-existent Pipeline.addConfigOverrideFile method

### DIFF
--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -215,11 +215,13 @@ class CmdLineFwk:
 
             elif action.action == "config":
 
-                pipeline.addConfigOverride(action.label, action.value[0], action.value[1])
+                # action value string is "field=value", split it at '='
+                field, _, value = action.value.partition("=")
+                pipeline.addConfigOverride(action.label, field, value)
 
             elif action.action == "configfile":
 
-                pipeline.addConfigOverrideFile(action.label, action.value)
+                pipeline.addConfigFile(action.label, action.value)
 
             else:
 


### PR DESCRIPTION
Fix config overrides handling.

Both -c and -C options had issues after latest refactoring of pipeline
interfaces, should be fixed now. Added unit test to check the expected
behavior.
