### PR TITLE
DM-22166: Fix pipetask --show=pipeline option

### DIFF
--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -397,7 +397,7 @@ class CmdLineFwk:
                     continue
 
             if showCommand == "pipeline":
-                for taskDef in pipeline:
+                for taskDef in pipeline.toExpandedPipeline():
                     print(taskDef)
             elif showCommand == "config":
                 self._showConfig(pipeline, showArgs)
@@ -463,7 +463,7 @@ class CmdLineFwk:
 
         tasks = util.filterTasks(pipeline, taskName)
         if not tasks:
-            print("Pipeline has not tasks named {}".format(taskName), file=sys.stderr)
+            print("Pipeline has no tasks named {}".format(taskName), file=sys.stderr)
             sys.exit(1)
 
         for taskDef in tasks:
@@ -487,14 +487,13 @@ class CmdLineFwk:
         if matHistory:
             taskName = matHistory.group(1)
             pattern = matHistory.group(2)
-        print(showArgs, taskName, pattern)
         if not pattern:
             print("Please provide a value with --show history (e.g. history=Task::param)", file=sys.stderr)
             sys.exit(1)
 
         tasks = util.filterTasks(pipeline, taskName)
         if not tasks:
-            print("Pipeline has not tasks named {}".format(taskName), file=sys.stderr)
+            print("Pipeline has no tasks named {}".format(taskName), file=sys.stderr)
             sys.exit(1)
 
         pattern = pattern.split(".")
@@ -523,7 +522,7 @@ class CmdLineFwk:
         ----------
         pipeline: `Pipeline`
         """
-        for taskDef in pipeline:
+        for taskDef in pipeline.toExpandedPipeline():
             print("### Subtasks for task `{}'".format(taskDef.taskName))
 
             for configName, taskName in util.subTaskIter(taskDef.config):

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -397,8 +397,7 @@ class CmdLineFwk:
                     continue
 
             if showCommand == "pipeline":
-                for taskDef in pipeline.toExpandedPipeline():
-                    print(taskDef)
+                print(pipeline)
             elif showCommand == "config":
                 self._showConfig(pipeline, showArgs)
             elif showCommand == "history":

--- a/python/lsst/ctrl/mpexec/util.py
+++ b/python/lsst/ctrl/mpexec/util.py
@@ -118,9 +118,9 @@ def filterTasks(pipeline, name):
     Lsit of `TaskDef` instances.
     """
     if not name:
-        return list(pipeline)
+        return list(pipeline.toExpandedPipeline())
     tasks = []
-    for taskDef in pipeline:
+    for taskDef in pipeline.toExpandedPipeline():
         if taskDef.label:
             if taskDef.label == name:
                 tasks.append(taskDef)

--- a/tests/test_cmdLineFwk.py
+++ b/tests/test_cmdLineFwk.py
@@ -361,6 +361,42 @@ class CmdLineFwkTestCase(unittest.TestCase):
         self.assertEqual(len(qgraph), 1)
         self.assertEqual(qgraph.countQuanta(), nQuanta)
 
+    def testShowPipeline(self):
+        """Test for --show options for pipeline.
+        """
+        fwk = CmdLineFwk()
+
+        actions = [
+            _ACTION_ADD_TASK("testUtil.AddTask:task"),
+            _ACTION_CONFIG("task:addend=100")
+        ]
+        args = _makeArgs(pipeline_actions=actions)
+        pipeline = fwk.makePipeline(args)
+
+        args.show = ["pipeline"]
+        fwk.showInfo(args, pipeline)
+        args.show = ["config"]
+        fwk.showInfo(args, pipeline)
+        args.show = ["history=task::addend"]
+        fwk.showInfo(args, pipeline)
+        args.show = ["tasks"]
+        fwk.showInfo(args, pipeline)
+
+    def testShowGraph(self):
+        """Test for --show options for quantum graph.
+        """
+        fwk = CmdLineFwk()
+
+        nQuanta = 2
+        butler, qgraph = makeSimpleQGraph(nQuanta)
+
+        args = _makeArgs()
+        args.show = ["graph"]
+        fwk.showInfo(args, pipeline=None, graph=qgraph)
+        # TODO: cannot test "workflow" option presently, it instanciates
+        # butler from command line options and there is no way to pass butler
+        # mock to that code.
+
 
 class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):
     pass


### PR DESCRIPTION
The code still expected pipeline to be a list of TaskDefs which is not
true anymore, need to call special method to get that list. Added unit
tests to check --show options and fixed all cases needed for correct
functioning.