### PR TITLE
DM-22198: pipetask qgraph Unexpected pipeline action: new_instrument

### DIFF
--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -205,7 +205,7 @@ class CmdLineFwk:
 
                 pipeline.addInstrument(action.value)
 
-            if action.action == "new_task":
+            elif action.action == "new_task":
 
                 pipeline.addTask(action.value, action.label)
 

--- a/python/lsst/ctrl/mpexec/cmdLineParser.py
+++ b/python/lsst/ctrl/mpexec/cmdLineParser.py
@@ -97,7 +97,7 @@ _ACTION_ADD_TASK = _PipelineActionType("new_task", "(?P<value>[^:]+)(:(?P<label>
 _ACTION_DELETE_TASK = _PipelineActionType("delete_task", "(?P<value>)(?P<label>.+)")
 _ACTION_CONFIG = _PipelineActionType("config", "(?P<label>.+):(?P<value>.+=.+)")
 _ACTION_CONFIG_FILE = _PipelineActionType("configfile", "(?P<label>.+):(?P<value>.+)")
-_ACTION_ADD_INSTRUMENT = _PipelineActionType("new_instrument", "(?P<value>[^:]+)")
+_ACTION_ADD_INSTRUMENT = _PipelineActionType("add_instrument", "(?P<value>[^:]+)")
 
 
 class _LogLevelAction(Action):


### PR DESCRIPTION
There was a type in action name and also a bug in logic introduced in
one of the recent commits, should be fixed now.