### PR TITLE
DM-21448: Don't look for components of unresolved datasets.

### DIFF
--- a/python/lsst/ctrl/mpexec/preExecInit.py
+++ b/python/lsst/ctrl/mpexec/preExecInit.py
@@ -145,24 +145,23 @@ class PreExecInit:
             Execution graph.
         """
         def _refComponents(refs):
-            """Return all dataset components recursively"""
+            """Return all resolved dataset components recursively."""
             for ref in refs:
-                yield ref
-                yield from _refComponents(ref.components.values())
+                if ref.id is not None:
+                    yield ref
+                    yield from _refComponents(ref.components.values())
 
         collection = self.butler.run.collection
         registry = self.butler.registry
 
-        # Main issue here is that the same DataRef can appear as input for
+        # Main issue here is that the same DatasetRef can appear as input for
         # many quanta, to keep them unique we first collect them into one
         # dict indexed by dataset id.
         id2ref = {}
         for taskDef, quantum in graph.quanta():
             for refs in quantum.predictedInputs.values():
                 for ref in _refComponents(refs):
-                    # skip intermediate datasets produced by other tasks
-                    if ref.id is not None:
-                        id2ref[ref.id] = ref
+                    id2ref[ref.id] = ref
         for initInput in graph.initInputs.values():
             id2ref[initInput.id] = initInput
 

--- a/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
+++ b/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
@@ -199,17 +199,21 @@ class SingleQuantumExecutor:
             Single Quantum instance.
         """
         butler = self.butler
-        for refs in quantum.predictedInputs.values():
-            for ref in refs:
+        for refsForDatasetType in quantum.predictedInputs.values():
+            newRefsForDatasetType = []
+            for ref in refsForDatasetType:
                 if ref.id is None:
-                    storedRef = butler.registry.find(butler.collection, ref.datasetType, ref.dataId)
-                    if storedRef is None:
+                    resolvedRef = butler.registry.find(butler.collection, ref.datasetType, ref.dataId)
+                    if resolvedRef is None:
                         raise ValueError(
                             f"Cannot find {ref.datasetType.name} with id {ref.dataId} "
                             f"in collection {butler.collection}."
                         )
-                    ref._id = storedRef.id
-                    _LOG.debug("Updated dataset ID for %s", ref)
+                    newRefsForDatasetType.append(resolvedRef)
+                    _LOG.debug("Updating dataset ID for %s", ref)
+                else:
+                    newRefsForDatasetType.append(ref)
+            refsForDatasetType[:] = newRefsForDatasetType
 
     def runQuantum(self, task, quantum, taskDef):
         """Execute task on a single quantum.


### PR DESCRIPTION
It never made sense for DatasetRefs without IDs to have components with IDs, and now DatasetRef guarantees that components is None if the ID is None.