### PR TITLE
DM-22504: Support for lsstDebug functionality in Gen3 middleware

### DIFF
--- a/python/lsst/ctrl/mpexec/cmdLineParser.py
+++ b/python/lsst/ctrl/mpexec/cmdLineParser.py
@@ -277,7 +277,8 @@ def _makeLoggingOptions(parser):
                        help="logging level; supported levels are [trace|debug|info|warn|error|fatal]",
                        metavar="LEVEL|COMPONENT=LEVEL")
     group.add_argument("--longlog", action="store_true", help="use a more verbose format for the logging")
-    group.add_argument("--debug", action="store_true", help="(deprecated) enable debugging output")
+    group.add_argument("--debug", action="store_true", dest="enableLsstDebug",
+                       help="enable debugging output using lsstDebug facility (imports debug.py)")
 
 
 def _makePipelineOptions(parser):

--- a/python/lsst/ctrl/mpexec/examples/calexpToCoaddTask.py
+++ b/python/lsst/ctrl/mpexec/examples/calexpToCoaddTask.py
@@ -7,6 +7,7 @@ from lsst.afw.image import ExposureF
 from lsst.pipe.base import (Struct, PipelineTask, PipelineTaskConfig,
                             PipelineTaskConnections)
 from lsst.pipe.base import connectionTypes as cT
+import lsstDebug
 
 _LOG = logging.getLogger(__name__.partition(".")[2])
 
@@ -42,6 +43,15 @@ class CalexpToCoaddTask(PipelineTask):
         `Struct` instance with produced result.
         """
         _LOG.info("executing %s: calexp=%s", self.getName(), calexp)
+
+        # To test lsstDebug function make a debug.py file with this contents
+        # somewhere in PYTHONPATH and run `pipetask` with --debug option:
+        #
+        #    import lsstDebug
+        #    lsstDebug.Info('lsst.ctrl.mpexec.examples.calexpToCoaddTask').display = True
+        #
+        if lsstDebug.Info(__name__).display:
+            _LOG.info("%s: display enabled", __name__)
 
         # output data, scalar in this case
         data = ExposureF(100, 100)

--- a/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
+++ b/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
@@ -54,12 +54,15 @@ class SingleQuantumExecutor:
     clobberOutput : `bool`, optional
         It `True` then override all existing output datasets in an output
         collection.
+    enableLsstDebug : `bool`, optional
+        Enable debugging with ``lsstDebug`` facility for a task.
     """
-    def __init__(self, butler, taskFactory, skipExisting=False, clobberOutput=False):
+    def __init__(self, butler, taskFactory, skipExisting=False, clobberOutput=False, enableLsstDebug=False):
         self.butler = butler
         self.taskFactory = taskFactory
         self.skipExisting = skipExisting
         self.clobberOutput = clobberOutput
+        self.enableLsstDebug = enableLsstDebug
 
     def execute(self, taskDef, quantum):
         """Execute PipelineTask on a single Quantum.
@@ -80,6 +83,15 @@ class SingleQuantumExecutor:
                       f"task={taskClass.__name__} dataId={quantum.dataId}.")
             return
         self.updateQuantumInputs(quantum)
+
+        # enable lsstDebug debugging
+        if self.enableLsstDebug:
+            try:
+                _LOG.debug("Will try to import debug.py")
+                import debug  # noqa:F401
+            except ImportError:
+                _LOG.warn("No 'debug' module found.")
+
         task = self.makeTask(taskClass, config)
         self.runQuantum(task, quantum, taskDef)
 

--- a/tests/test_cmdLineFwk.py
+++ b/tests/test_cmdLineFwk.py
@@ -150,6 +150,7 @@ def _makeArgs(pipeline=None, qgraph=None, pipeline_actions=(), order_pipeline=Fa
     args.init_only = False
     args.processes = 1
     args.profile = None
+    args.enableLsstDebug = False
     return args
 
 

--- a/tests/test_cmdLineParser.py
+++ b/tests/test_cmdLineParser.py
@@ -154,7 +154,7 @@ class CmdLineParserTestCase(unittest.TestCase):
         self.assertRaises(_Error, parser.parse_args)
 
         # know attributes to appear in parser output for all subcommands
-        common_options = "loglevel longlog debug subcommand subparser".split()
+        common_options = "loglevel longlog enableLsstDebug subcommand subparser".split()
 
         # test for the set of options defined in each command
         args = parser.parse_args(
@@ -199,7 +199,7 @@ class CmdLineParserTestCase(unittest.TestCase):
             """.split())
         self.assertFalse(args.clobberConfig)
         self.assertFalse(args.clobberVersions)
-        self.assertFalse(args.debug)
+        self.assertFalse(args.enableLsstDebug)
         self.assertFalse(args.doraise)
         self.assertEqual(args.input, {})
         self.assertEqual(args.loglevel, [])
@@ -243,7 +243,7 @@ class CmdLineParserTestCase(unittest.TestCase):
             """.split())
         self.assertTrue(args.clobberConfig)
         self.assertTrue(args.clobberVersions)
-        self.assertTrue(args.debug)
+        self.assertTrue(args.enableLsstDebug)
         self.assertTrue(args.doraise)
         self.assertEqual(args.input, {"": ["inputColl"]})
         self.assertEqual(args.loglevel, [(None, 'DEBUG'), ('component', 'TRACE')])


### PR DESCRIPTION
The --debug option existed but did not do anyhting, added code that
imports `debug.py` when that option is set. Compared to CmdLineTask in
`pipetask` I do it in two places, once before PreExecInit (in case
someone needs to debug task construction) and once before running each
task. Latter is not needed if `multiprocess` uses 'fork' start method
but it is impossible to guarantee that is always true on all platforms.