### PR TITLE
DM-22301: Improve printing of task configs

### DIFF
--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -462,11 +462,10 @@ class CmdLineFwk:
                         self._pattern = re.compile(fnmatch.translate(pattern), re.IGNORECASE)
 
                 def write(self, showStr):
-                    showStr = showStr.rstrip()
                     # Strip off doc string line(s) and cut off at "=" for string matching
-                    matchStr = showStr.split("\n")[-1].split("=")[0]
+                    matchStr = showStr.rstrip().split("\n")[-1].split("=")[0]
                     if self._pattern.search(matchStr):
-                        print(u"\n" + showStr)
+                        sys.stdout.write(showStr)
 
             fd = FilteredStream(pattern)
         else:

--- a/python/lsst/ctrl/mpexec/cmdLineParser.py
+++ b/python/lsst/ctrl/mpexec/cmdLineParser.py
@@ -459,11 +459,14 @@ def makeParser(fromfile_prefix_chars='@', parser_class=ArgumentParser, **kwargs)
 
         subparser.add_argument("--show", metavar="ITEM|ITEM=VALUE", action="append", default=[],
                                help="Dump various info to standard output. Possible items are: "
-                               "`config', `config=[Task/]<PATTERN>' or "
+                               "`config', `config=[Task::]<PATTERN>' or "
                                "`config=[Task::]<PATTERN>:NOIGNORECASE' to dump configuration "
-                               "possibly matching given pattern; `history=<FIELD>' to dump "
-                               "configuration history for a field,  field name is specified as "
-                               "[Task::][SubTask.]Field;  `pipeline' to show pipeline composition; "
+                               "fields possibly matching given pattern and/or task label; "
+                               "`history=<FIELD>' to dump configuration history for a field, "
+                               "field name is specified as [Task::][SubTask.]Field; "
+                               "`dump-config', `dump-config=Task' to dump complete configuration "
+                               "for a task given its label or all tasks; "
+                               "`pipeline' to show pipeline composition; "
                                "`graph' to show information about quanta; "
                                "`workflow' to show information about quanta and their dependency; "
                                "`tasks' to show task composition.")


### PR DESCRIPTION
The `--show=config` option now prints configuration without imports. New
option `--show=dump-config[=Task]` now dumps complete configuration for
a task (or all tasks) with all imports.

Config history option was improved as well, one can use natural configuration
syntax for configurable fields, exactly as it appears in config overrides, e.g.
`--show history="measurePsf.psfDeterminer['pca'].lam"`.