### PR TITLE
DM-24370: Support extensible scheduling in pipetask

### DIFF
--- a/python/lsst/ctrl/mpexec/__init__.py
+++ b/python/lsst/ctrl/mpexec/__init__.py
@@ -22,6 +22,7 @@
 from .cmdLineFwk import *
 from .cmdLineParser import *
 from .dotTools import *
+from .executionGraphFixup import *
 from .mpGraphExecutor import *
 from .preExecInit import *
 from .quantumGraphExecutor import *

--- a/python/lsst/ctrl/mpexec/cmdLineParser.py
+++ b/python/lsst/ctrl/mpexec/cmdLineParser.py
@@ -393,6 +393,11 @@ def _makeExecOptions(parser):
     group.add_argument("--timeout", type=float,
                        help="Timeout for multiprocessing; maximum wall time (sec)")
 
+    # run-time graph fixup option
+    group.add_argument("--graph-fixup", type=str, default=None,
+                       help="Name of the class or factory method which makes an instance "
+                       "used for execution graph fixup.")
+
 # ------------------------
 #  Exported definitions --
 # ------------------------

--- a/python/lsst/ctrl/mpexec/execFixupDataId.py
+++ b/python/lsst/ctrl/mpexec/execFixupDataId.py
@@ -1,0 +1,111 @@
+# This file is part of ctrl_mpexec.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+__all__ = ['ExecutionGraphFixup']
+
+from typing import Any, Iterable, Sequence, Tuple, Union
+
+from lsst.pipe.base import QuantumIterData
+from .executionGraphFixup import ExecutionGraphFixup
+
+
+class ExecFixupDataId(ExecutionGraphFixup):
+    """Implementation of ExecutionGraphFixup for ordering of tasks based
+    on DataId values.
+
+    This class is a trivial implementation mostly useful as an example,
+    though it can be used to make actual fixup instances by defining
+    a method that instantiates it, e.g.::
+
+        # lsst/ap/verify/ci_fixup.py
+
+        from lsst.ctrl.mpexec.execFixupDataId import ExecFixupDataId
+
+        def assoc_fixup():
+            return ExecFixupDataId(taskLabel="ap_assoc",
+                                   dimensions=("visit", "detector"))
+
+
+    and then executing pipetask::
+
+        pipetask run --graph-fixup=lsst.ap.verify.ci_fixup.assoc_fixup ...
+
+    This will add new dependencies between quanta executed by the task with
+    label "ap_assoc". Quanta with higher visit number will depend on quanta
+    with lower visit number and their execution will wait until lower visit
+    number finishes.
+
+    Parameters
+    ----------
+    taskLabel : `str`
+        The label of the task for which to add dependencies.
+    dimensions : `str` or sequence [`str`]
+        One or more dimension names, quanta execution will be ordered
+        according to values of these dimensions.
+    reverse : `bool`, optional
+        If `False` (default) then quanta with higher values of dimensions
+        will be executed after quanta with lower values, otherwise the order
+        is reversed.
+    """
+
+    def __init__(self, taskLabel: str, dimensions: Union[str, Sequence[str]], reverse: bool = False):
+        self.taskLabel = taskLabel
+        self.dimensions = dimensions
+        self.reverse = reverse
+        if isinstance(self.dimensions, str):
+            self.dimensions = (self.dimensions, )
+        else:
+            self.dimensions = tuple(self.dimensions)
+
+    def _key(self, qdata: QuantumIterData) -> Tuple[Any, ...]:
+        """Produce comparison key for quantum data.
+
+        Parameters
+        ----------
+        qdata : `QuantumIterData`
+
+        Returns
+        -------
+        key : `tuple`
+        """
+        dataId = qdata.quantum.dataId
+        key = tuple(dataId[dim] for dim in self.dimensions)
+        return key
+
+    def fixupQuanta(self, quanta: Iterable[QuantumIterData]) -> Iterable[QuantumIterData]:
+        # Docstring inherited from ExecutionGraphFixup.fixupQuanta
+        quanta = list(quanta)
+        # Index task quanta by the key
+        keyQuanta = {}
+        for qdata in quanta:
+            if qdata.taskDef.label == self.taskLabel:
+                key = self._key(qdata)
+                keyQuanta.setdefault(key, []).append(qdata)
+        if not keyQuanta:
+            raise ValueError(f"Cannot find task with label {self.taskLabel}")
+        # order keys
+        keys = sorted(keyQuanta.keys(), reverse=self.reverse)
+        # for each quanta in a key add dependency to all quanta in a preceding key
+        for prev_key, key in zip(keys, keys[1:]):
+            prev_indices = frozenset(qdata.index for qdata in keyQuanta[prev_key])
+            for qdata in keyQuanta[key]:
+                qdata.dependencies |= prev_indices
+        return quanta

--- a/python/lsst/ctrl/mpexec/executionGraphFixup.py
+++ b/python/lsst/ctrl/mpexec/executionGraphFixup.py
@@ -1,0 +1,65 @@
+# This file is part of ctrl_mpexec.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+__all__ = ['ExecutionGraphFixup']
+
+from abc import ABC, abstractmethod
+from typing import Iterable
+
+from lsst.pipe.base import QuantumIterData
+
+
+class ExecutionGraphFixup(ABC):
+    """Interface for classes which update quantum graphs before execution.
+
+    Primary goal of this class is to modify quanta dependencies which may
+    not be possible to reflect in a quantum graph using standard tools.
+    One known use case for that is to guarantee particular execution order
+    of visits in CI jobs for cases when outcome depends on the processing
+    order of visits (e.g. AP association pipeline).
+
+    Instances of this class receive pre-ordered sequence of quanta
+    (`~lsst.pipe.base.QuantumIterData` instances) and they are allowed to
+    modify quanta data in place, for example update ``dependencies`` field to
+    add additional dependencies. Returned list of quanta will be re-ordered
+    once again by the graph executor to reflect new dependencies.
+    """
+
+    @abstractmethod
+    def fixupQuanta(self, quanta: Iterable[QuantumIterData]) -> Iterable[QuantumIterData]:
+        """Update quanta in a graph.
+
+        Potentially anything in the graph could be changed if it does not
+        break executor assumptions. Returned quanta will be re-ordered by
+        executor, if modifications result in a dependency cycle the executor
+        will raise an exception.
+
+        Parameters
+        ----------
+        quanta : iterable [`~lsst.pipe.base.QuantumIterData`]
+            Iterable of topologically ordered quanta as returned from
+            `lsst.pipe.base.QuantumGraph.traverse` method.
+
+        Yieds
+        -----
+        quantum : `~lsst.pipe.base.QuantumIterData`
+        """
+        raise NotImplementedError

--- a/python/lsst/ctrl/mpexec/quantumGraphExecutor.py
+++ b/python/lsst/ctrl/mpexec/quantumGraphExecutor.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-__all__ = ['QuantumGraphExecutor']
+__all__ = ["QuantumExecutor", "QuantumGraphExecutor"]
 
 # -------------------------------
 #  Imports of standard modules --
@@ -31,6 +31,31 @@ from abc import ABC, abstractmethod
 # -----------------------------
 
 
+class QuantumExecutor(ABC):
+    """Class which abstracts execution of a single Quantum.
+
+    In general implementation should not depend on execution model and
+    execution should always happen in-process. Main reason for existence
+    of this class is to provide do-nothing implementation that can be used
+    in the unit tests.
+    """
+
+    @abstractmethod
+    def execute(self, taskDef, quantum, butler):
+        """Execute single quantum.
+
+        Parameters
+        ----------
+        taskDef : `~lsst.pipe.base.TaskDef`
+            Task definition structure.
+        quantum : `~lsst.daf.butler.Quantum`
+            Quantum for this execution.
+        butler : `~lsst.daf.butler.Butler`
+            Data butler instance
+        """
+        raise NotImplementedError
+
+
 class QuantumGraphExecutor(ABC):
     """Class which abstracts QuantumGraph execution.
 
@@ -39,7 +64,7 @@ class QuantumGraphExecutor(ABC):
     """
 
     @abstractmethod
-    def execute(self, graph, butler, taskFactory):
+    def execute(self, graph, butler):
         """Execute whole graph.
 
         Implementation of this method depends on particular execution model
@@ -53,6 +78,5 @@ class QuantumGraphExecutor(ABC):
             Execution graph.
         butler : `~lsst.daf.butler.Butler`
             Data butler instance
-        taskFactory : `~lsst.pipe.base.TaskFactory`
-            Task factory.
         """
+        raise NotImplementedError

--- a/tests/test_cmdLineFwk.py
+++ b/tests/test_cmdLineFwk.py
@@ -150,6 +150,7 @@ def _makeArgs(pipeline=None, qgraph=None, pipeline_actions=(), order_pipeline=Fa
     args.processes = 1
     args.profile = None
     args.enableLsstDebug = False
+    args.graph_fixup = None
     return args
 
 

--- a/tests/test_cmdLineParser.py
+++ b/tests/test_cmdLineParser.py
@@ -188,7 +188,7 @@ class CmdLineParserTestCase(unittest.TestCase):
             run -t taskname
             """.split())
         run_options = qgraph_options + """register_dataset_types skip_init_writes
-                      init_only processes profile timeout doraise""".split()
+                      init_only processes profile timeout doraise graph_fixup""".split()
         self.assertEqual(set(vars(args).keys()), set(common_options + run_options))
         self.assertEqual(args.subcommand, 'run')
 
@@ -215,6 +215,7 @@ class CmdLineParserTestCase(unittest.TestCase):
         self.assertEqual(args.processes, 1)
         self.assertIsNone(args.profile)
         self.assertIsNone(args.timeout)
+        self.assertIsNone(args.graph_fixup)
         self.assertEqual(args.pipeline_actions, [PipelineAction("new_task", None, "taskname")])
         self.assertEqual(args.show, [])
         self.assertIsNotNone(args.subparser)
@@ -251,6 +252,7 @@ class CmdLineParserTestCase(unittest.TestCase):
         self.assertEqual(args.processes, 66)
         self.assertEqual(args.profile, 'profile.out')
         self.assertEqual(args.timeout, 10.10)
+        self.assertIsNone(args.graph_fixup)
         self.assertEqual(args.show, ['config', 'config=Task.*'])
         self.assertEqual(args.pipeline_actions, [PipelineAction("new_task", "label", "taskname"),
                                                  PipelineAction("config", "label", "a=b"),
@@ -291,6 +293,7 @@ class CmdLineParserTestCase(unittest.TestCase):
             --save-qgraph=newqgraph.pickle
             --pipeline-dot pipe.dot
             --qgraph-dot qgraph.dot
+            --graph-fixup lsst.ctrl.mpexec.Fixup
             """.split())
         self.assertEqual(args.show, ['config', 'config=Task.*'])
         self.assertEqual(args.pipeline_actions, [PipelineAction("new_task", None, "task1"),
@@ -312,6 +315,7 @@ class CmdLineParserTestCase(unittest.TestCase):
         self.assertEqual(args.save_qgraph, "newqgraph.pickle")
         self.assertEqual(args.pipeline_dot, "pipe.dot")
         self.assertEqual(args.qgraph_dot, "qgraph.dot")
+        self.assertEqual(args.graph_fixup, "lsst.ctrl.mpexec.Fixup")
 
     def testCmdLinePipeline(self):
 

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -1,0 +1,88 @@
+# This file is part of ctrl_mpexec.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Simple unit test for cmdLineFwk module.
+"""
+
+import logging
+import unittest
+
+from lsst.ctrl.mpexec import MPGraphExecutor, QuantumExecutor
+from lsst.ctrl.mpexec.execFixupDataId import ExecFixupDataId
+from testUtil import makeSimpleQGraph
+
+
+logging.basicConfig(level=logging.INFO)
+
+
+class QuantumExecutorMock(QuantumExecutor):
+    """Mock class for QuantumExecutor
+    """
+    def __init__(self):
+        self.taskDefs = []
+        self.quanta = []
+
+    def execute(self, taskDef, quantum, butler):
+        self.taskDefs += [taskDef]
+        self.quanta += [quantum]
+
+    def getDataIds(self, field):
+        """Returns values for dataId field for each visited quanta"""
+        return [quantum.dataId[field] for quantum in self.quanta]
+
+
+class MPGraphExecutorTestCase(unittest.TestCase):
+    """A test case for MPGraphExecutor class
+    """
+
+    def test_mpexec(self):
+        """Make simple graph and execute"""
+
+        nQuanta = 3
+        butler, qgraph = makeSimpleQGraph(nQuanta)
+
+        qexec = QuantumExecutorMock()
+        mpexec = MPGraphExecutor(numProc=1, timeout=1, quantumExecutor=qexec)
+        mpexec.execute(qgraph, butler)
+        # the order is not defined
+        self.assertCountEqual(qexec.getDataIds("detector"), [0, 1, 2])
+
+    def test_mpexec_fixup(self):
+        """Make simple graph and execute, add dependencies"""
+
+        nQuanta = 3
+        butler, qgraph = makeSimpleQGraph(nQuanta)
+
+        for reverse in (False, True):
+            qexec = QuantumExecutorMock()
+            fixup = ExecFixupDataId("task1", "detector", reverse=reverse)
+            mpexec = MPGraphExecutor(numProc=1, timeout=1, quantumExecutor=qexec,
+                                     executionGraphFixup=fixup)
+            mpexec.execute(qgraph, butler)
+
+            expected = [0, 1, 2]
+            if reverse:
+                expected = list(reversed(expected))
+            self.assertEqual(qexec.getDataIds("detector"), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Executor classes have been refactored to better separate concerns. An
optional "graph fixup" instance can be passed to graph executor which
allows some modifications of the execution graph (e.g. changing
dependencies between quanta). Command line now has an option to import
and instantiate graph fixup object and pass it to executor. Unit test
was added to verify new functionality.