### PR TITLE
DM-24797: Store per-run information (configs, software versions) in butler repo

### DIFF
--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -681,7 +681,8 @@ class CmdLineFwk:
         preExecInit = PreExecInit(butler, taskFactory, args.skip_existing)
         preExecInit.initialize(graph,
                                saveInitOutputs=not args.skip_init_writes,
-                               registerDatasetTypes=args.register_dataset_types)
+                               registerDatasetTypes=args.register_dataset_types,
+                               saveVersions=not args.no_versions)
 
         if not args.init_only:
             graphFixup = self._importGraphFixup(args)

--- a/python/lsst/ctrl/mpexec/cmdLineParser.py
+++ b/python/lsst/ctrl/mpexec/cmdLineParser.py
@@ -276,6 +276,9 @@ def _makeMetaOutputOptions(parser):
     group.add_argument("--register-dataset-types", dest="register_dataset_types", default=False,
                        action="store_true",
                        help="Register DatasetTypes that do not already exist in the Registry.")
+    group.add_argument("--no-versions", dest="no_versions", default=False,
+                       action="store_true",
+                       help="Do not save or check package versions.")
 
 
 def _makeLoggingOptions(parser):

--- a/python/lsst/ctrl/mpexec/executionGraphFixup.py
+++ b/python/lsst/ctrl/mpexec/executionGraphFixup.py
@@ -58,8 +58,8 @@ class ExecutionGraphFixup(ABC):
             Iterable of topologically ordered quanta as returned from
             `lsst.pipe.base.QuantumGraph.traverse` method.
 
-        Yieds
-        -----
+        Yields
+        ------
         quantum : `~lsst.pipe.base.QuantumIterData`
         """
         raise NotImplementedError

--- a/tests/testUtil.py
+++ b/tests/testUtil.py
@@ -196,10 +196,13 @@ def registerDatasetTypes(registry, pipeline):
         Iterable of TaskDef instances.
     """
     for taskDef in pipeline:
+        configDatasetType = DatasetType(taskDef.configDatasetName, {},
+                                        storageClass="Config",
+                                        universe=registry.dimensions)
         datasetTypes = pipeBase.TaskDatasetTypes.fromTaskDef(taskDef, registry=registry)
         for datasetType in itertools.chain(datasetTypes.initInputs, datasetTypes.initOutputs,
                                            datasetTypes.inputs, datasetTypes.outputs,
-                                           datasetTypes.prerequisites):
+                                           datasetTypes.prerequisites, [configDatasetType]):
             _LOG.info("Registering %s with registry", datasetType)
             # this is a no-op if it already exists and is consistent,
             # and it raises if it is inconsistent.

--- a/tests/testUtil.py
+++ b/tests/testUtil.py
@@ -24,6 +24,7 @@
 
 __all__ = ["AddTaskConfig", "AddTask", "AddTaskFactoryMock", "ButlerMock"]
 
+import contextlib
 import itertools
 import logging
 import numpy
@@ -142,6 +143,10 @@ class ButlerMock:
         """Make a dict key out of dataId.
         """
         return frozenset(dataId.items())
+
+    @contextlib.contextmanager
+    def transaction(self):
+        yield
 
     def get(self, datasetRefOrType, dataId=None, parameters=None, **kwds):
         datasetType, dataId = self._standardizeArgs(datasetRefOrType, dataId, **kwds)

--- a/tests/testUtil.py
+++ b/tests/testUtil.py
@@ -199,10 +199,14 @@ def registerDatasetTypes(registry, pipeline):
         configDatasetType = DatasetType(taskDef.configDatasetName, {},
                                         storageClass="Config",
                                         universe=registry.dimensions)
+        packagesDatasetType = DatasetType("packages", {},
+                                          storageClass="Packages",
+                                          universe=registry.dimensions)
         datasetTypes = pipeBase.TaskDatasetTypes.fromTaskDef(taskDef, registry=registry)
         for datasetType in itertools.chain(datasetTypes.initInputs, datasetTypes.initOutputs,
                                            datasetTypes.inputs, datasetTypes.outputs,
-                                           datasetTypes.prerequisites, [configDatasetType]):
+                                           datasetTypes.prerequisites,
+                                           [configDatasetType, packagesDatasetType]):
             _LOG.info("Registering %s with registry", datasetType)
             # this is a no-op if it already exists and is consistent,
             # and it raises if it is inconsistent.

--- a/tests/test_cmdLineFwk.py
+++ b/tests/test_cmdLineFwk.py
@@ -145,6 +145,7 @@ def _makeArgs(pipeline=None, qgraph=None, pipeline_actions=(), order_pipeline=Fa
     args.output = {}
     args.register_dataset_types = False
     args.skip_init_writes = False
+    args.no_versions = False
     args.skip_existing = False
     args.init_only = False
     args.processes = 1
@@ -331,6 +332,7 @@ class CmdLineFwkTestCase(unittest.TestCase):
 
         AddTask.stopAt = -1
         args.skip_existing = True
+        args.no_versions = True
         fwk.runPipeline(qgraph, taskFactory, args, butler=butler)
         self.assertEqual(AddTask.countExec, nQuanta)
 

--- a/tests/test_cmdLineParser.py
+++ b/tests/test_cmdLineParser.py
@@ -188,7 +188,8 @@ class CmdLineParserTestCase(unittest.TestCase):
             run -t taskname
             """.split())
         run_options = qgraph_options + """register_dataset_types skip_init_writes
-                      init_only processes profile timeout doraise graph_fixup""".split()
+                      init_only processes profile timeout doraise graph_fixup
+                      no_versions""".split()
         self.assertEqual(set(vars(args).keys()), set(common_options + run_options))
         self.assertEqual(args.subcommand, 'run')
 


### PR DESCRIPTION
PreExecInit now saves task configurations for every task in a pipeline,
the names of dataset types are fixed as `{taskLabel}_config`. It also saves
package versions in a dataset with fixed type name "packages". Dataset
types are registered together with all other dataset types when 
--register-dataset-types option is specified.