### PR TITLE
DM-25222: Fix handling of skip-existing in PreExecInit

### DIFF
--- a/python/lsst/ctrl/mpexec/preExecInit.py
+++ b/python/lsst/ctrl/mpexec/preExecInit.py
@@ -255,25 +255,36 @@ class PreExecInit:
             compatible.
         """
         packages = Packages.fromSystem()
+        _LOG.debug("want to save packages: %s", packages)
         datasetType = "packages"
+        dataId = {}
         oldPackages = None
-        if self.skipExisting:
-            try:
-                oldPackages = self.butler.get(datasetType, {})
-            except LookupError:
-                pass
-        if oldPackages is not None:
-            # Note that because we can only detect python modules that have been imported, the stored
-            # list of products may be more or less complete than what we have now.  What's important is
-            # that the products that are in common have the same version.
-            diff = packages.difference(oldPackages)
-            if diff:
-                versions_str = "; ".join(f"{pkg}: {diff[pkg][1]} vs {diff[pkg][0]}" for pkg in diff)
-                raise TypeError(f"Package versions mismatch: ({versions_str})")
-            # Update the old set of packages in case we have more packages that haven't been persisted.
-            extra = packages.extra(oldPackages)
-            if extra:
-                oldPackages.update(packages)
-                self.butler.put(oldPackages, datasetType, {})
-        else:
-            self.butler.put(packages, datasetType, {})
+        # start transaction to rollback any changes on exceptions
+        with self.butler.transaction():
+            if self.skipExisting:
+                try:
+                    oldPackages = self.butler.get(datasetType, dataId, collections=[self.butler.run])
+                    _LOG.debug("old packages: %s", oldPackages)
+                except LookupError:
+                    pass
+            if oldPackages is not None:
+                # Note that because we can only detect python modules that have been imported, the stored
+                # list of products may be more or less complete than what we have now.  What's important is
+                # that the products that are in common have the same version.
+                diff = packages.difference(oldPackages)
+                if diff:
+                    versions_str = "; ".join(f"{pkg}: {diff[pkg][1]} vs {diff[pkg][0]}" for pkg in diff)
+                    raise TypeError(f"Package versions mismatch: ({versions_str})")
+                else:
+                    _LOG.debug("new packages are consistent with old")
+                # Update the old set of packages in case we have more packages that haven't been persisted.
+                extra = packages.extra(oldPackages)
+                if extra:
+                    _LOG.debug("extra packages: %s", extra)
+                    oldPackages.update(packages)
+                    # have to remove existing dataset first, butler nas no replace option
+                    ref = self.butler.registry.findDataset(datasetType, dataId, collections=[self.butler.run])
+                    self.butler.pruneDatasets([ref], unstore=True, purge=True)
+                    self.butler.put(oldPackages, datasetType, dataId)
+            else:
+                self.butler.put(packages, datasetType, dataId)

--- a/tests/testUtil.py
+++ b/tests/testUtil.py
@@ -156,7 +156,7 @@ class ButlerMock:
         dsdata = self.datasets.get(dsTypeName)
         if dsdata:
             return dsdata.get(key)
-        return None
+        raise LookupError
 
     def put(self, obj, datasetRefOrType, dataId=None, producer=None, **kwds):
         datasetType, dataId = self._standardizeArgs(datasetRefOrType, dataId, **kwds)

--- a/tests/test_preExecInit.py
+++ b/tests/test_preExecInit.py
@@ -1,0 +1,102 @@
+# This file is part of ctrl_mpexec.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Simple unit test for PreExecInit class.
+"""
+
+import unittest
+
+from lsst.ctrl.mpexec import PreExecInit
+from testUtil import makeSimpleQGraph, AddTaskFactoryMock
+
+
+class PreExecInitTestCase(unittest.TestCase):
+    """A test case for PreExecInit
+    """
+
+    def test_saveInitOutputs(self):
+        taskFactory = AddTaskFactoryMock()
+        for skipExisting in (False, True):
+            with self.subTest(skipExisting=skipExisting):
+                butler, qgraph = makeSimpleQGraph()
+                preExecInit = PreExecInit(butler=butler, taskFactory=taskFactory, skipExisting=skipExisting)
+                preExecInit.saveInitOutputs(qgraph)
+
+    def test_saveInitOutputs_twice(self):
+        taskFactory = AddTaskFactoryMock()
+        for skipExisting in (False, True):
+            with self.subTest(skipExisting=skipExisting):
+                butler, qgraph = makeSimpleQGraph()
+                preExecInit = PreExecInit(butler=butler, taskFactory=taskFactory, skipExisting=skipExisting)
+                preExecInit.saveInitOutputs(qgraph)
+                if skipExisting:
+                    # will ignore this
+                    preExecInit.saveInitOutputs(qgraph)
+                else:
+                    # Second time it will fail
+                    with self.assertRaises(Exception):
+                        preExecInit.saveInitOutputs(qgraph)
+
+    def test_saveConfigs(self):
+        for skipExisting in (False, True):
+            with self.subTest(skipExisting=skipExisting):
+                butler, qgraph = makeSimpleQGraph()
+                preExecInit = PreExecInit(butler=butler, taskFactory=None, skipExisting=skipExisting)
+                preExecInit.saveConfigs(qgraph)
+
+    def test_saveConfigs_twice(self):
+        for skipExisting in (False, True):
+            with self.subTest(skipExisting=skipExisting):
+                butler, qgraph = makeSimpleQGraph()
+                preExecInit = PreExecInit(butler=butler, taskFactory=None, skipExisting=skipExisting)
+                preExecInit.saveConfigs(qgraph)
+                if skipExisting:
+                    # will ignore this
+                    preExecInit.saveConfigs(qgraph)
+                else:
+                    # Second time it will fail
+                    with self.assertRaises(Exception):
+                        preExecInit.saveConfigs(qgraph)
+
+    def test_savePackageVersions(self):
+        for skipExisting in (False, True):
+            with self.subTest(skipExisting=skipExisting):
+                butler, qgraph = makeSimpleQGraph()
+                preExecInit = PreExecInit(butler=butler, taskFactory=None, skipExisting=skipExisting)
+                preExecInit.savePackageVersions(qgraph)
+
+    def test_savePackageVersions_twice(self):
+        for skipExisting in (False, True):
+            with self.subTest(skipExisting=skipExisting):
+                butler, qgraph = makeSimpleQGraph()
+                preExecInit = PreExecInit(butler=butler, taskFactory=None, skipExisting=skipExisting)
+                preExecInit.savePackageVersions(qgraph)
+                if skipExisting:
+                    # if this is the same packages then it should not attempt to save
+                    preExecInit.savePackageVersions(qgraph)
+                else:
+                    # second time it will fail
+                    with self.assertRaises(Exception):
+                        preExecInit.savePackageVersions(qgraph)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
PreExecInit expected butler.get() to return None for missing datasets,
while in reality it raises LookupError. Fixing this and also adding unit
test for this.