### PR TITLE
DM-26230: Improve pipetask dignostics on timeouts

### DIFF
--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -687,7 +687,8 @@ class CmdLineFwk:
             quantumExecutor = SingleQuantumExecutor(taskFactory,
                                                     skipExisting=args.skip_existing,
                                                     enableLsstDebug=args.enableLsstDebug)
-            executor = MPGraphExecutor(numProc=args.processes, timeout=self.MP_TIMEOUT,
+            timeout = self.MP_TIMEOUT if args.timeout is None else args.timeout
+            executor = MPGraphExecutor(numProc=args.processes, timeout=timeout,
                                        quantumExecutor=quantumExecutor,
                                        executionGraphFixup=graphFixup)
             with util.profile(args.profile, _LOG):

--- a/tests/testUtil.py
+++ b/tests/testUtil.py
@@ -138,6 +138,15 @@ class ButlerMock:
                 datasetType = self.registry.getDatasetType(datasetRefOrType)
         return datasetType, dataId
 
+    @classmethod
+    def _unpickle(cls, fullRegistry, run):
+        return cls(fullRegistry, run)
+
+    def __reduce__(self):
+        """Support pickling.
+        """
+        return (ButlerMock._unpickle, (self.fullRegistry, self.run))
+
     @staticmethod
     def key(dataId):
         """Make a dict key out of dataId.

--- a/tests/test_cmdLineFwk.py
+++ b/tests/test_cmdLineFwk.py
@@ -184,6 +184,7 @@ def _makeArgs(pipeline=None, qgraph=None, pipeline_actions=(), order_pipeline=Fa
     args.profile = None
     args.enableLsstDebug = False
     args.graph_fixup = None
+    args.timeout = None
     return args
 
 


### PR DESCRIPTION
Catches TimeoutError and makes a new exception with more context info
about task and quantum. Unit test extended to simulate that case.