### PR TITLE
DM-26136: Improve handling of crashes in pipetask

### DIFF
--- a/python/lsst/ctrl/mpexec/cli/cmd/commands.py
+++ b/python/lsst/ctrl/mpexec/cli/cmd/commands.py
@@ -167,6 +167,7 @@ def qgraph(ctx, *args, **kwargs):
 @opt.profile_option()
 @opt.processes_option()
 @opt.timeout_option()
+@opt.fail_fast_option()
 @opt.graph_fixup_option()
 @option_section(sectionText="Meta-information output options:")
 @opt.skip_init_writes_option()

--- a/python/lsst/ctrl/mpexec/cli/opt/options.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/options.py
@@ -232,3 +232,8 @@ task_option = MWOptionDecorator("-t", "--task",
 
 timeout_option = MWOptionDecorator("--timeout",
                                    help="Timeout for multiprocessing; maximum wall time (sec).")
+
+fail_fast_option = MWOptionDecorator("--fail-fast",
+                                     help=unwrap("""Stop processing at first error, default is to process
+                                                 as many tasks as possible."""),
+                                     is_flag=True)

--- a/python/lsst/ctrl/mpexec/cli/script/run.py
+++ b/python/lsst/ctrl/mpexec/cli/script/run.py
@@ -47,7 +47,8 @@ def run(do_raise,
         prune_replaced,
         data_query,
         skip_existing,
-        debug):
+        debug,
+        fail_fast):
     """Implements the command line interface `pipetask run` subcommand, should
     only be called by command line tools and unit test code that test this
     function.
@@ -127,6 +128,9 @@ def run(do_raise,
     debug : `bool`
         If true, enable debugging output using lsstDebug facility (imports
         debug.py).
+    fail_fast : `bool`
+        If true then stop processing at first error, otherwise process as many
+        tasks as possible.
     """
 
     if log_level is not None:
@@ -157,7 +161,8 @@ def run(do_raise,
                      prune_replaced,
                      data_query,
                      skip_existing,
-                     debug):
+                     debug,
+                     fail_fast):
             self.do_raise = do_raise
             self.graph_fixup = graph_fixup
             self.init_only = init_only
@@ -177,13 +182,14 @@ def run(do_raise,
             self.data_query = data_query
             self.skip_existing = skip_existing
             self.enableLsstDebug = debug
+            self.fail_fast = fail_fast
 
     args = RunArgs(do_raise=do_raise, graph_fixup=graph_fixup, init_only=init_only, no_versions=no_versions,
                    processes=processes, profile=profile, skip_init_writes=skip_init_writes, timeout=timeout,
                    register_dataset_types=register_dataset_types, butler_config=butler_config, input=input,
                    output=output, output_run=output_run, extend_run=extend_run, replace_run=replace_run,
                    prune_replaced=prune_replaced, data_query=data_query, skip_existing=skip_existing,
-                   debug=debug)
+                   debug=debug, fail_fast=fail_fast)
 
     f = CmdLineFwk()
     taskFactory = TaskFactory()

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -690,6 +690,7 @@ class CmdLineFwk:
             timeout = self.MP_TIMEOUT if args.timeout is None else args.timeout
             executor = MPGraphExecutor(numProc=args.processes, timeout=timeout,
                                        quantumExecutor=quantumExecutor,
+                                       failFast=args.fail_fast,
                                        executionGraphFixup=graphFixup)
             with util.profile(args.profile, _LOG):
                 executor.execute(graph, butler)

--- a/python/lsst/ctrl/mpexec/cmdLineParser.py
+++ b/python/lsst/ctrl/mpexec/cmdLineParser.py
@@ -393,6 +393,9 @@ def _makeExecOptions(parser):
     group.add_argument("-j", "--processes", type=int, default=1, help="Number of processes to use")
     group.add_argument("--timeout", type=float,
                        help="Timeout for multiprocessing; maximum wall time (sec)")
+    group.add_argument("--fail-fast", action="store_true", default=False,
+                       help="Stop processing at first error, default is to process as many tasks "
+                       "as possible.")
 
     # run-time graph fixup option
     group.add_argument("--graph-fixup", type=str, default=None,

--- a/python/lsst/ctrl/mpexec/mpGraphExecutor.py
+++ b/python/lsst/ctrl/mpexec/mpGraphExecutor.py
@@ -24,6 +24,7 @@ __all__ = ["MPGraphExecutor", "MPGraphExecutorError", "MPTimeoutError"]
 # -------------------------------
 #  Imports of standard modules --
 # -------------------------------
+import copy
 from enum import Enum
 import logging
 import multiprocessing
@@ -72,6 +73,10 @@ class _Job:
         quantumExecutor : `QuantumExecutor`
             Executor for single quantum.
         """
+        # Butler can have live database connections which is a problem with
+        # fork-type activation. Make a copy of butler, this guarantees that
+        # no database is open right after copy.
+        butler = copy.copy(butler)
         taskDef = self.qdata.taskDef
         quantum = self.qdata.quantum
         self.process = multiprocessing.Process(

--- a/python/lsst/ctrl/mpexec/quantumGraphExecutor.py
+++ b/python/lsst/ctrl/mpexec/quantumGraphExecutor.py
@@ -52,6 +52,11 @@ class QuantumExecutor(ABC):
             Quantum for this execution.
         butler : `~lsst.daf.butler.Butler`
             Data butler instance
+
+        Notes
+        -----
+        Any exception raised by the task or code that wraps task execution is
+        propagated to the caller of this method.
         """
         raise NotImplementedError
 
@@ -74,7 +79,7 @@ class QuantumGraphExecutor(ABC):
 
         Parameters
         ----------
-        graph : `~lsst.pip.base.QuantumGraph`
+        graph : `~lsst.pipe.base.QuantumGraph`
             Execution graph.
         butler : `~lsst.daf.butler.Butler`
             Data butler instance

--- a/tests/test_cliCmd.py
+++ b/tests/test_cliCmd.py
@@ -121,7 +121,8 @@ class RunTestCase(CliCmdTestBase, unittest.TestCase):
                     replace_run=False,
                     skip_existing=False,
                     skip_init_writes=False,
-                    timeout=None)
+                    timeout=None,
+                    fail_fast=False)
 
     @staticmethod
     def command():

--- a/tests/test_cmdLineFwk.py
+++ b/tests/test_cmdLineFwk.py
@@ -185,6 +185,7 @@ def _makeArgs(pipeline=None, qgraph=None, pipeline_actions=(), order_pipeline=Fa
     args.enableLsstDebug = False
     args.graph_fixup = None
     args.timeout = None
+    args.fail_fast = False
     return args
 
 

--- a/tests/test_cmdLineParser.py
+++ b/tests/test_cmdLineParser.py
@@ -189,7 +189,7 @@ class CmdLineParserTestCase(unittest.TestCase):
             """.split())
         run_options = qgraph_options + """register_dataset_types skip_init_writes
                       init_only processes profile timeout doraise graph_fixup
-                      no_versions""".split()
+                      no_versions fail_fast""".split()
         self.assertEqual(set(vars(args).keys()), set(common_options + run_options))
         self.assertEqual(args.subcommand, 'run')
 

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -23,64 +23,175 @@
 """
 
 import logging
+from multiprocessing import Manager
 import time
+from types import SimpleNamespace
 import unittest
 
-from lsst.ctrl.mpexec import MPGraphExecutor, MPTimeoutError, QuantumExecutor
+from lsst.ctrl.mpexec import MPGraphExecutor, MPGraphExecutorError, MPTimeoutError, QuantumExecutor
 from lsst.ctrl.mpexec.execFixupDataId import ExecFixupDataId
-from testUtil import makeSimpleQGraph
 
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.DEBUG)
+
+_LOG = logging.getLogger(__name__)
 
 
 class QuantumExecutorMock(QuantumExecutor):
     """Mock class for QuantumExecutor
     """
-    def __init__(self, sleep=None):
-        self.taskDefs = []
+    def __init__(self, mp=False):
         self.quanta = []
-        self.sleep = sleep
+        if mp:
+            # in multiprocess mode use shared list
+            manager = Manager()
+            self.quanta = manager.list()
 
     def execute(self, taskDef, quantum, butler):
-        self.taskDefs += [taskDef]
-        self.quanta += [quantum]
-        if self.sleep:
-            time.sleep(self.sleep)
+        _LOG.debug("QuantumExecutorMock.execute: taskDef=%s dataId=%s", taskDef, quantum.dataId)
+        if taskDef.taskClass:
+            # only works for TaskMockMP class below
+            taskDef.taskClass().runQuantum()
+        self.quanta.append(quantum)
 
     def getDataIds(self, field):
         """Returns values for dataId field for each visited quanta"""
         return [quantum.dataId[field] for quantum in self.quanta]
 
 
+class QuantumIterDataMock:
+    """Simple class to mock QuantumIterData.
+    """
+    def __init__(self, index, taskDef, **dataId):
+        self.index = index
+        self.taskDef = taskDef
+        self.quantum = SimpleNamespace(dataId=dataId)
+        self.dependencies = set()
+
+
+class QuantumGraphMock:
+    """Mock for quantum graph.
+    """
+    def __init__(self, qdata):
+        self.qdata = qdata
+
+    def traverse(self):
+        return self.qdata
+
+
+class TaskMockMP:
+    """Simple mock class for task supporting multiprocessing.
+    """
+    canMultiprocess = True
+
+    def runQuantum(self):
+        _LOG.debug("TaskMockMP.runQuantum")
+        pass
+
+
+class TaskMockFail:
+    """Simple mock class for task which fails.
+    """
+    canMultiprocess = True
+
+    def runQuantum(self):
+        _LOG.debug("TaskMockFail.runQuantum")
+        raise ValueError("expected failure")
+
+
+class TaskMockSleep:
+    """Simple mock class for task which fails.
+    """
+    canMultiprocess = True
+
+    def runQuantum(self):
+        _LOG.debug("TaskMockSleep.runQuantum")
+        time.sleep(3.)
+
+
+class TaskMockNoMP:
+    """Simple mock class for task not supporting multiprocessing.
+    """
+    canMultiprocess = False
+
+
+class TaskDefMock:
+    """Simple mock class for task definition in a pipeline.
+    """
+    def __init__(self, taskName="Task", config=None, taskClass=TaskMockMP, label="task1"):
+        self.taskName = taskName
+        self.config = config
+        self.taskClass = taskClass
+        self.label = label
+
+    def __str__(self):
+        return f"TaskDefMock(taskName={self.taskName}, taskClass={self.taskClass.__name__})"
+
+
 class MPGraphExecutorTestCase(unittest.TestCase):
     """A test case for MPGraphExecutor class
     """
 
-    def test_mpexec(self):
+    def test_mpexec_nomp(self):
         """Make simple graph and execute"""
 
-        nQuanta = 3
-        butler, qgraph = makeSimpleQGraph(nQuanta)
+        taskDef = TaskDefMock()
+        qgraph = QuantumGraphMock([
+            QuantumIterDataMock(index=i, taskDef=taskDef, detector=i) for i in range(3)
+        ])
 
+        # run in single-process mode
         qexec = QuantumExecutorMock()
-        mpexec = MPGraphExecutor(numProc=1, timeout=1, quantumExecutor=qexec)
-        mpexec.execute(qgraph, butler)
-        # the order is not defined
+        mpexec = MPGraphExecutor(numProc=1, timeout=100, quantumExecutor=qexec)
+        mpexec.execute(qgraph, butler=None)
+        self.assertEqual(qexec.getDataIds("detector"), [0, 1, 2])
+
+    def test_mpexec_mp(self):
+        """Make simple graph and execute"""
+
+        taskDef = TaskDefMock()
+        qgraph = QuantumGraphMock([
+            QuantumIterDataMock(index=i, taskDef=taskDef, detector=i) for i in range(3)
+        ])
+
+        # run in multi-process mode, the order of results is not defined
+        qexec = QuantumExecutorMock(mp=True)
+        mpexec = MPGraphExecutor(numProc=3, timeout=100, quantumExecutor=qexec)
+        mpexec.execute(qgraph, butler=None)
         self.assertCountEqual(qexec.getDataIds("detector"), [0, 1, 2])
 
-    def test_mpexec_fixup(self):
-        """Make simple graph and execute, add dependencies"""
+    def test_mpexec_nompsupport(self):
+        """Try to run MP for task that has no MP support which should fail
+        """
 
-        nQuanta = 3
-        butler, qgraph = makeSimpleQGraph(nQuanta)
+        taskDef = TaskDefMock(taskClass=TaskMockNoMP)
+        qgraph = QuantumGraphMock([
+            QuantumIterDataMock(index=i, taskDef=taskDef, detector=i) for i in range(3)
+        ])
+
+        # run in multi-process mode
+        qexec = QuantumExecutorMock()
+        mpexec = MPGraphExecutor(numProc=3, timeout=100, quantumExecutor=qexec)
+        with self.assertRaises(MPGraphExecutorError):
+            mpexec.execute(qgraph, butler=None)
+
+    def test_mpexec_fixup(self):
+        """Make simple graph and execute, add dependencies by executing fixup code
+        """
+
+        taskDef = TaskDefMock()
 
         for reverse in (False, True):
+
+            qgraph = QuantumGraphMock([
+                QuantumIterDataMock(index=i, taskDef=taskDef, detector=i) for i in range(3)
+            ])
+
             qexec = QuantumExecutorMock()
             fixup = ExecFixupDataId("task1", "detector", reverse=reverse)
-            mpexec = MPGraphExecutor(numProc=1, timeout=1, quantumExecutor=qexec,
+            mpexec = MPGraphExecutor(numProc=1, timeout=100, quantumExecutor=qexec,
                                      executionGraphFixup=fixup)
-            mpexec.execute(qgraph, butler)
+            mpexec.execute(qgraph, butler=None)
 
             expected = [0, 1, 2]
             if reverse:
@@ -88,16 +199,99 @@ class MPGraphExecutorTestCase(unittest.TestCase):
             self.assertEqual(qexec.getDataIds("detector"), expected)
 
     def test_mpexec_timeout(self):
-        """Make simple graph and execute, add dependencies"""
+        """Fail due to timeout"""
 
-        nQuanta = 3
-        butler, qgraph = makeSimpleQGraph(nQuanta)
+        taskDef = TaskDefMock()
+        taskDefSleep = TaskDefMock(taskClass=TaskMockSleep)
+        qgraph = QuantumGraphMock([
+            QuantumIterDataMock(index=0, taskDef=taskDef, detector=0),
+            QuantumIterDataMock(index=1, taskDef=taskDefSleep, detector=1),
+            QuantumIterDataMock(index=2, taskDef=taskDef, detector=2),
+        ])
 
-        for reverse in (False, True):
-            qexec = QuantumExecutorMock(sleep=3)
-            mpexec = MPGraphExecutor(numProc=3, timeout=1, quantumExecutor=qexec)
-            with self.assertRaises(MPTimeoutError):
-                mpexec.execute(qgraph, butler)
+        # with failFast we'll get immediate MPTimeoutError
+        qexec = QuantumExecutorMock(mp=True)
+        mpexec = MPGraphExecutor(numProc=3, timeout=1, quantumExecutor=qexec, failFast=True)
+        with self.assertRaises(MPTimeoutError):
+            mpexec.execute(qgraph, butler=None)
+
+        # with failFast=False exception happens after last task finishes
+        qexec = QuantumExecutorMock(mp=True)
+        mpexec = MPGraphExecutor(numProc=3, timeout=1, quantumExecutor=qexec, failFast=False)
+        with self.assertRaises(MPGraphExecutorError):
+            mpexec.execute(qgraph, butler=None)
+        self.assertCountEqual(qexec.getDataIds("detector"), [0, 2])
+
+    def test_mpexec_failure(self):
+        """Failure in one task should not stop other tasks"""
+
+        taskDef = TaskDefMock()
+        taskDefFail = TaskDefMock(taskClass=TaskMockFail)
+        qgraph = QuantumGraphMock([
+            QuantumIterDataMock(index=0, taskDef=taskDef, detector=0),
+            QuantumIterDataMock(index=1, taskDef=taskDefFail, detector=1),
+            QuantumIterDataMock(index=2, taskDef=taskDef, detector=2),
+        ])
+
+        qexec = QuantumExecutorMock(mp=True)
+        mpexec = MPGraphExecutor(numProc=3, timeout=100, quantumExecutor=qexec)
+        with self.assertRaises(MPGraphExecutorError):
+            mpexec.execute(qgraph, butler=None)
+        self.assertCountEqual(qexec.getDataIds("detector"), [0, 2])
+
+    def test_mpexec_failure_dep(self):
+        """Failure in one task should skip dependents"""
+
+        taskDef = TaskDefMock()
+        taskDefFail = TaskDefMock(taskClass=TaskMockFail)
+        qdata = [
+            QuantumIterDataMock(index=0, taskDef=taskDef, detector=0),
+            QuantumIterDataMock(index=1, taskDef=taskDefFail, detector=1),
+            QuantumIterDataMock(index=2, taskDef=taskDef, detector=2),
+            QuantumIterDataMock(index=3, taskDef=taskDef, detector=3),
+            QuantumIterDataMock(index=4, taskDef=taskDef, detector=4),
+        ]
+        qdata[2].dependencies.add(1)
+        qdata[4].dependencies.add(3)
+        qdata[4].dependencies.add(2)
+
+        qgraph = QuantumGraphMock(qdata)
+
+        qexec = QuantumExecutorMock(mp=True)
+        mpexec = MPGraphExecutor(numProc=3, timeout=100, quantumExecutor=qexec)
+        with self.assertRaises(MPGraphExecutorError):
+            mpexec.execute(qgraph, butler=None)
+        self.assertCountEqual(qexec.getDataIds("detector"), [0, 3])
+
+    def test_mpexec_failure_failfast(self):
+        """Fast fail stops quickly.
+
+        Timing delay of task #3 should be sufficient to process
+        failure and raise exception.
+        """
+
+        taskDef = TaskDefMock()
+        taskDefFail = TaskDefMock(taskClass=TaskMockFail)
+        taskDefSleep = TaskDefMock(taskClass=TaskMockSleep)
+        qdata = [
+            QuantumIterDataMock(index=0, taskDef=taskDef, detector=0),
+            QuantumIterDataMock(index=1, taskDef=taskDefFail, detector=1),
+            QuantumIterDataMock(index=2, taskDef=taskDef, detector=2),
+            QuantumIterDataMock(index=3, taskDef=taskDefSleep, detector=3),
+            QuantumIterDataMock(index=4, taskDef=taskDef, detector=4),
+        ]
+        qdata[1].dependencies.add(0)
+        qdata[2].dependencies.add(1)
+        qdata[4].dependencies.add(3)
+        qdata[4].dependencies.add(2)
+
+        qgraph = QuantumGraphMock(qdata)
+
+        qexec = QuantumExecutorMock(mp=True)
+        mpexec = MPGraphExecutor(numProc=3, timeout=100, quantumExecutor=qexec, failFast=True)
+        with self.assertRaises(MPGraphExecutorError):
+            mpexec.execute(qgraph, butler=None)
+        self.assertCountEqual(qexec.getDataIds("detector"), [0])
 
 
 if __name__ == "__main__":

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -218,7 +218,7 @@ class MPGraphExecutorTestCase(unittest.TestCase):
         # with failFast=False exception happens after last task finishes
         qexec = QuantumExecutorMock(mp=True)
         mpexec = MPGraphExecutor(numProc=3, timeout=1, quantumExecutor=qexec, failFast=False)
-        with self.assertRaises(MPGraphExecutorError):
+        with self.assertRaises(MPTimeoutError):
             mpexec.execute(qgraph, butler=None)
         self.assertCountEqual(qexec.getDataIds("detector"), [0, 2])
 


### PR DESCRIPTION
Replaced use of multiprocessing Pool with manual process management based on `Process` class. Crashes in sub-processes should be handled correctly now. Exceptions are not propagated to main process, they will appear in the log when subprocess fail, main process will just list all tasks that failed.

Implemented "keep running" as default option, there is new command line option `--fail-fast` which turns on old behavior.
