### PR TITLE
Rename README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,4 +4,4 @@ ctrl_mpexec
 
 ``ctrl_mpexec`` is a package in the `LSST Science Pipelines <https://pipelines.lsst.io>`_.
 
-.. Add a brief (few sentence) description of what this package provides.
+It provides a PipelineTask execution framework.

--- a/README.rst
+++ b/README.rst
@@ -4,4 +4,4 @@ ctrl_mpexec
 
 ``ctrl_mpexec`` is a package in the `LSST Science Pipelines <https://pipelines.lsst.io>`_.
 
-It provides a PipelineTask execution framework.
+It provides a PipelineTask execution framework for single-node processing.


### PR DESCRIPTION
The file isn't in markdown format, so GitHub is rendering it incorrectly.