### PR TITLE
DM-26131: Add --clobber-partial-outputs option to pipetask

### DIFF
--- a/python/lsst/ctrl/mpexec/cli/opt/optionGroups.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/optionGroups.py
@@ -113,6 +113,7 @@ class execution_options(OptionGroup):  # noqa: N801
     def __init__(self):
         self.decorators = [
             option_section(sectionText="Execution options:"),
+            ctrlMpExecOpts.clobber_partial_outputs_option(),
             ctrlMpExecOpts.do_raise_option(),
             ctrlMpExecOpts.profile_option(),
             ctrlMpExecOpts.processes_option(),

--- a/python/lsst/ctrl/mpexec/cli/opt/options.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/options.py
@@ -214,6 +214,13 @@ skip_existing_option = MWOptionDecorator("--skip-existing",
                                          is_flag=True)
 
 
+clobber_partial_outputs_option = MWOptionDecorator("--clobber-partial-outputs",
+                                                   help=unwrap("""Remove incomplete outputs from previous
+                                                               execution of the same quantum before new
+                                                               execution."""),
+                                                   is_flag=True)
+
+
 skip_init_writes_option = MWOptionDecorator("--skip-init-writes",
                                             help=unwrap("""Do not write collection-wide 'init output' datasets
                                                         (e.g.schemas)."""),

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -686,6 +686,7 @@ class CmdLineFwk:
             graphFixup = self._importGraphFixup(args)
             quantumExecutor = SingleQuantumExecutor(taskFactory,
                                                     skipExisting=args.skip_existing,
+                                                    clobberPartialOutputs=args.clobber_partial_outputs,
                                                     enableLsstDebug=args.enableLsstDebug)
             timeout = self.MP_TIMEOUT if args.timeout is None else args.timeout
             executor = MPGraphExecutor(numProc=args.processes, timeout=timeout,

--- a/python/lsst/ctrl/mpexec/cmdLineParser.py
+++ b/python/lsst/ctrl/mpexec/cmdLineParser.py
@@ -361,7 +361,8 @@ def _makeQuantumGraphOptions(parser):
                        default=False, action="store_true",
                        help=("If all Quantum outputs already exist in the output RUN collection "
                              "then that Quantum will be excluded from the QuantumGraph.  "
-                             "Requires --extend-run."))
+                             "Requires --extend-run. When this option is used with 'run' command "
+                             "it skips execution of quantum if all its output exist."))
     group.add_argument("-q", "--save-qgraph", dest="save_qgraph",
                        help="Location for storing a serialized quantum graph definition "
                        "(pickle file).",
@@ -385,6 +386,9 @@ def _makeExecOptions(parser):
     parser : `argparse.ArgumentParser`
     """
     group = parser.add_argument_group("Execution options")
+    group.add_argument("--clobber-partial-outputs", action="store_true", default=False,
+                       help=("Remove incomplete outputs from previous execution of the same "
+                             "quantum before new execution."))
     group.add_argument("--doraise", action="store_true",
                        help="raise an exception on error (else log a message and continue)?")
     group.add_argument("--profile", metavar="PATH", help="Dump cProfile statistics to filename")

--- a/tests/test_cliScript.py
+++ b/tests/test_cliScript.py
@@ -93,13 +93,22 @@ config.saveMetadata=True
 config.addend=100
 
 # name for connection input
-config.connections.input='add_input'
+config.connections.input='add_dataset{in}'
 
 # name for connection output
-config.connections.output='add_output'
+config.connections.output='add_dataset{out}'
+
+# name for connection output2
+config.connections.output2='add2_dataset{out}'
 
 # name for connection initout
-config.connections.initout='add_init_output'"""),
+config.connections.initout='add_init_output{out}'
+
+# Template parameter used to format corresponding field template parameter
+config.connections.in='_in'
+
+# Template parameter used to format corresponding field template parameter
+config.connections.out='_out'"""),
 
             # history will contain machine-specific paths, TBD how to verify
             ShowInfo("history=task::addend", None),

--- a/tests/test_cmdLineParser.py
+++ b/tests/test_cmdLineParser.py
@@ -189,7 +189,7 @@ class CmdLineParserTestCase(unittest.TestCase):
             """.split())
         run_options = qgraph_options + """register_dataset_types skip_init_writes
                       init_only processes profile timeout doraise graph_fixup
-                      no_versions fail_fast""".split()
+                      no_versions fail_fast clobber_partial_outputs""".split()
         self.assertEqual(set(vars(args).keys()), set(common_options + run_options))
         self.assertEqual(args.subcommand, 'run')
 
@@ -214,6 +214,7 @@ class CmdLineParserTestCase(unittest.TestCase):
         self.assertEqual(args.extend_run, False)
         self.assertEqual(args.replace_run, False)
         self.assertEqual(args.processes, 1)
+        self.assertFalse(args.clobber_partial_outputs)
         self.assertIsNone(args.profile)
         self.assertIsNone(args.timeout)
         self.assertIsNone(args.graph_fixup)
@@ -235,6 +236,7 @@ class CmdLineParserTestCase(unittest.TestCase):
             -j 66
             --profile profile.out
             --timeout 10.10
+            --clobber-partial-outputs
             -t taskname:label
             --show config
             --show config=Task.*
@@ -251,6 +253,7 @@ class CmdLineParserTestCase(unittest.TestCase):
         self.assertTrue(args.longlog)
         self.assertEqual(args.output, "outputColl")
         self.assertEqual(args.processes, 66)
+        self.assertTrue(args.clobber_partial_outputs)
         self.assertEqual(args.profile, 'profile.out')
         self.assertEqual(args.timeout, 10.10)
         self.assertIsNone(args.graph_fixup)

--- a/tests/test_preExecInit.py
+++ b/tests/test_preExecInit.py
@@ -22,10 +22,25 @@
 """Simple unit test for PreExecInit class.
 """
 
+import contextlib
+import shutil
+import tempfile
 import unittest
 
 from lsst.ctrl.mpexec import PreExecInit
 from testUtil import makeSimpleQGraph, AddTaskFactoryMock
+
+
+@contextlib.contextmanager
+def temporaryDirectory():
+    """Context manager that creates and destroys temporary directory.
+
+    Difference from `tempfile.TemporaryDirectory` is that it ignores errors
+    when deleting a directory, which may happen with some filesystems.
+    """
+    tmpdir = tempfile.mkdtemp()
+    yield tmpdir
+    shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 class PreExecInitTestCase(unittest.TestCase):
@@ -36,66 +51,74 @@ class PreExecInitTestCase(unittest.TestCase):
         taskFactory = AddTaskFactoryMock()
         for skipExisting in (False, True):
             with self.subTest(skipExisting=skipExisting):
-                butler, qgraph = makeSimpleQGraph()
-                preExecInit = PreExecInit(butler=butler, taskFactory=taskFactory, skipExisting=skipExisting)
-                preExecInit.saveInitOutputs(qgraph)
+                with temporaryDirectory() as tmpdir:
+                    butler, qgraph = makeSimpleQGraph(root=tmpdir)
+                    preExecInit = PreExecInit(butler=butler, taskFactory=taskFactory,
+                                              skipExisting=skipExisting)
+                    preExecInit.saveInitOutputs(qgraph)
 
     def test_saveInitOutputs_twice(self):
         taskFactory = AddTaskFactoryMock()
         for skipExisting in (False, True):
             with self.subTest(skipExisting=skipExisting):
-                butler, qgraph = makeSimpleQGraph()
-                preExecInit = PreExecInit(butler=butler, taskFactory=taskFactory, skipExisting=skipExisting)
-                preExecInit.saveInitOutputs(qgraph)
-                if skipExisting:
-                    # will ignore this
+                with temporaryDirectory() as tmpdir:
+                    butler, qgraph = makeSimpleQGraph(root=tmpdir)
+                    preExecInit = PreExecInit(butler=butler, taskFactory=taskFactory,
+                                              skipExisting=skipExisting)
                     preExecInit.saveInitOutputs(qgraph)
-                else:
-                    # Second time it will fail
-                    with self.assertRaises(Exception):
+                    if skipExisting:
+                        # will ignore this
                         preExecInit.saveInitOutputs(qgraph)
+                    else:
+                        # Second time it will fail
+                        with self.assertRaises(Exception):
+                            preExecInit.saveInitOutputs(qgraph)
 
     def test_saveConfigs(self):
         for skipExisting in (False, True):
             with self.subTest(skipExisting=skipExisting):
-                butler, qgraph = makeSimpleQGraph()
-                preExecInit = PreExecInit(butler=butler, taskFactory=None, skipExisting=skipExisting)
-                preExecInit.saveConfigs(qgraph)
+                with temporaryDirectory() as tmpdir:
+                    butler, qgraph = makeSimpleQGraph(root=tmpdir)
+                    preExecInit = PreExecInit(butler=butler, taskFactory=None, skipExisting=skipExisting)
+                    preExecInit.saveConfigs(qgraph)
 
     def test_saveConfigs_twice(self):
         for skipExisting in (False, True):
             with self.subTest(skipExisting=skipExisting):
-                butler, qgraph = makeSimpleQGraph()
-                preExecInit = PreExecInit(butler=butler, taskFactory=None, skipExisting=skipExisting)
-                preExecInit.saveConfigs(qgraph)
-                if skipExisting:
-                    # will ignore this
+                with temporaryDirectory() as tmpdir:
+                    butler, qgraph = makeSimpleQGraph(root=tmpdir)
+                    preExecInit = PreExecInit(butler=butler, taskFactory=None, skipExisting=skipExisting)
                     preExecInit.saveConfigs(qgraph)
-                else:
-                    # Second time it will fail
-                    with self.assertRaises(Exception):
+                    if skipExisting:
+                        # will ignore this
                         preExecInit.saveConfigs(qgraph)
+                    else:
+                        # Second time it will fail
+                        with self.assertRaises(Exception):
+                            preExecInit.saveConfigs(qgraph)
 
     def test_savePackageVersions(self):
         for skipExisting in (False, True):
             with self.subTest(skipExisting=skipExisting):
-                butler, qgraph = makeSimpleQGraph()
-                preExecInit = PreExecInit(butler=butler, taskFactory=None, skipExisting=skipExisting)
-                preExecInit.savePackageVersions(qgraph)
+                with temporaryDirectory() as tmpdir:
+                    butler, qgraph = makeSimpleQGraph(root=tmpdir)
+                    preExecInit = PreExecInit(butler=butler, taskFactory=None, skipExisting=skipExisting)
+                    preExecInit.savePackageVersions(qgraph)
 
     def test_savePackageVersions_twice(self):
         for skipExisting in (False, True):
             with self.subTest(skipExisting=skipExisting):
-                butler, qgraph = makeSimpleQGraph()
-                preExecInit = PreExecInit(butler=butler, taskFactory=None, skipExisting=skipExisting)
-                preExecInit.savePackageVersions(qgraph)
-                if skipExisting:
-                    # if this is the same packages then it should not attempt to save
+                with temporaryDirectory() as tmpdir:
+                    butler, qgraph = makeSimpleQGraph(root=tmpdir)
+                    preExecInit = PreExecInit(butler=butler, taskFactory=None, skipExisting=skipExisting)
                     preExecInit.savePackageVersions(qgraph)
-                else:
-                    # second time it will fail
-                    with self.assertRaises(Exception):
+                    if skipExisting:
+                        # if this is the same packages then it should not attempt to save
                         preExecInit.savePackageVersions(qgraph)
+                    else:
+                        # second time it will fail
+                        with self.assertRaises(Exception):
+                            preExecInit.savePackageVersions(qgraph)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Extended executor to remove partial outputs if this option is specified.
Added unit test for this new feature, made some refactoring in unit
tests to use true butler instead of my own mock.