### PR TITLE
DM-26780: Enable -@ for reading command line options

### DIFF
--- a/python/lsst/ctrl/mpexec/cli/cmd/commands.py
+++ b/python/lsst/ctrl/mpexec/cli/cmd/commands.py
@@ -40,7 +40,7 @@ forwardEpilog = unwrap("""Options marked with (f) are forwarded to the next subc
                 are chained in the same command execution. Previous values may be overridden by passing new
                 option values into the next subcommand.""")
 
-buildEpilog = unwrap(f"""Notes:
+buildEpilog = unwrap("""Notes:
 
 --task, --delete, --config, --config-file, and --instrument action options can
 appear multiple times; all values are used, in order left to right.

--- a/python/lsst/ctrl/mpexec/cli/cmd/commands.py
+++ b/python/lsst/ctrl/mpexec/cli/cmd/commands.py
@@ -22,7 +22,8 @@
 import click
 
 from lsst.daf.butler.cli.opt import (config_file_option,
-                                     config_option)
+                                     config_option,
+                                     options_file_option)
 from lsst.daf.butler.cli.utils import (cli_handle_exception,
                                        MWCommand,
                                        MWCtxObj,
@@ -80,6 +81,7 @@ def _doBuild(ctx, **kwargs):
 @ctrlMpExecOpts.show_option()
 @ctrlMpExecOpts.pipeline_build_options()
 @option_section(sectionText="")
+@options_file_option()
 def build(ctx, **kwargs):
     """Build and optionally save pipeline definition.
 
@@ -96,6 +98,7 @@ def build(ctx, **kwargs):
 @ctrlMpExecOpts.qgraph_options()
 @ctrlMpExecOpts.butler_options()
 @option_section(sectionText="")
+@options_file_option()
 def qgraph(ctx, **kwargs):
     """Build and optionally save quantum graph.
     """
@@ -114,6 +117,7 @@ def qgraph(ctx, **kwargs):
 @ctrlMpExecOpts.execution_options()
 @ctrlMpExecOpts.meta_info_options()
 @option_section(sectionText="")
+@options_file_option()
 def run(ctx, **kwargs):
     """Build and execute pipeline and quantum graph.
     """

--- a/python/lsst/ctrl/mpexec/cli/opt/options.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/options.py
@@ -94,7 +94,7 @@ order_pipeline_option = MWOptionDecorator("--order-pipeline",
 
 
 output_option = MWOptionDecorator("-o", "--output",
-                                  help=unwrap(f"""Name of the output CHAINED collection. This may either be an
+                                  help=unwrap("""Name of the output CHAINED collection. This may either be an
                                               existing CHAINED collection to use as both input and output
                                               (incompatible with --input), or a new CHAINED collection created
                                               to include all inputs (requires --input). In both cases, the
@@ -161,7 +161,7 @@ register_dataset_types_option = MWOptionDecorator("--register-dataset-types",
 
 
 replace_run_option = MWOptionDecorator("--replace-run",
-                                       help=unwrap(f"""Before creating a new RUN collection in an existing
+                                       help=unwrap("""Before creating a new RUN collection in an existing
                                                    CHAINED collection, remove the first child collection
                                                    (which must be of type RUN). This can be used to repeatedly
                                                    write to the same (parent) collection during development,

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -237,9 +237,9 @@ class _ButlerFactory:
             raise ValueError(f"Output run '{self.outputRun.name}' already exists, but "
                              f"--extend-run was not given.")
         if args.prune_replaced and not args.replace_run:
-            raise ValueError(f"--prune-replaced requires --replace-run.")
+            raise ValueError("--prune-replaced requires --replace-run.")
         if args.replace_run and (self.output is None or not self.output.exists):
-            raise ValueError(f"--output must point to an existing CHAINED collection for --replace-run.")
+            raise ValueError("--output must point to an existing CHAINED collection for --replace-run.")
 
     @classmethod
     def _makeReadParts(cls, args: argparse.Namespace):
@@ -891,7 +891,7 @@ class CmdLineFwk:
             if primary:
                 print(f"    {primary}")
             else:
-                print(f"    (disassembled artifact)")
+                print("    (disassembled artifact)")
                 for compName, compUri in components.items():
                     print(f"        {compName}: {compUri}")
 


### PR DESCRIPTION
(I notice that pipetask (non-click) does support `@file` for this).

Requires lsst/daf_butler#377