### PR TITLE
DM-27390: un-adapt to some daf_butler API changes I thought better of.

### DIFF
--- a/tests/test_cmdLineFwk.py
+++ b/tests/test_cmdLineFwk.py
@@ -496,7 +496,7 @@ class CmdLineFwkTestCaseWithButler(unittest.TestCase):
         self.assertEqual(taskFactory.countExec, nQuanta)
 
         # need to refresh collections explicitly (or make new butler/registry)
-        butler.registry._collections.refresh(butler.registry.dimensions)
+        butler.registry._collections.refresh()
         collections = set(butler.registry.queryCollections(...))
         self.assertEqual(collections, {"test", "output", "output/run1"})
 
@@ -516,7 +516,7 @@ class CmdLineFwkTestCaseWithButler(unittest.TestCase):
         args.output_run = "output/run2"
         fwk.runPipeline(copy.deepcopy(qgraph), taskFactory, args)
 
-        butler.registry._collections.refresh(butler.registry.dimensions)
+        butler.registry._collections.refresh()
         collections = set(butler.registry.queryCollections(...))
         self.assertEqual(collections, {"test", "output", "output/run1", "output/run2"})
 
@@ -535,7 +535,7 @@ class CmdLineFwkTestCaseWithButler(unittest.TestCase):
         args.output_run = "output/run3"
         fwk.runPipeline(copy.deepcopy(qgraph), taskFactory, args)
 
-        butler.registry._collections.refresh(butler.registry.dimensions)
+        butler.registry._collections.refresh()
         collections = set(butler.registry.queryCollections(...))
         self.assertEqual(collections, {"test", "output", "output/run1", "output/run2", "output/run3"})
 
@@ -558,7 +558,7 @@ class CmdLineFwkTestCaseWithButler(unittest.TestCase):
         args.output_run = "output/run4"
         fwk.runPipeline(copy.deepcopy(qgraph), taskFactory, args)
 
-        butler.registry._collections.refresh(butler.registry.dimensions)
+        butler.registry._collections.refresh()
         collections = set(butler.registry.queryCollections(...))
         # output/run3 should disappear now
         self.assertEqual(collections, {"test", "output", "output/run1", "output/run2", "output/run4"})


### PR DESCRIPTION
This partially reverts 75fc90fb5a6ea285e7c9459854d7fa4d9a8d567e.