### PR TITLE
DM-27519: Improve printing of config history

### DIFF
--- a/python/lsst/ctrl/mpexec/cli/opt/options.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/options.py
@@ -185,7 +185,7 @@ show_option = MWOptionDecorator("--show",
                                             `config=[Task::]<PATTERN>:NOIGNORECASE` to dump configuration
                                             fields possibly matching given pattern and/or task label;
                                             `history=<FIELD>` to dump configuration history for a field, field
-                                            name is specified as [Task::][SubTask.]Field; `dump-config`,
+                                            name is specified as [Task::]<PATTERN>; `dump-config`,
                                             `dump-config=Task` to dump complete configuration for a task given
                                             its label or all tasks; `pipeline` to show pipeline composition;
                                             `graph` to show information about quanta; `workflow` to show


### PR DESCRIPTION
I tried to find a better way to navigate Config structure but in the end
decided that `eval` is the easiest and most natural way to do it.
I did not want to parse the printed attribute representation myself (do
not want to re-implement `eval`) and navigating Config class hierarchy
needs too much effort.