### PR TITLE
DM-27500: add a comment in butler & pipetask subcommand about more options in butler --help

### DIFF
--- a/python/lsst/ctrl/mpexec/cli/cmd/commands.py
+++ b/python/lsst/ctrl/mpexec/cli/cmd/commands.py
@@ -26,22 +26,16 @@ from lsst.daf.butler.cli.opt import (config_file_option,
                                      options_file_option)
 from lsst.daf.butler.cli.utils import (cli_handle_exception,
                                        Mocker,
-                                       MWCommand,
                                        MWCtxObj,
                                        option_section,
                                        unwrap)
-import lsst.daf.butler.cli.opt as dafButlerOpts
 import lsst.obs.base.cli.opt as obsBaseOpts
 from .. import opt as ctrlMpExecOpts
 from .. import script
-from ..utils import makePipelineActions
+from ..utils import makePipelineActions, PipetaskCommand
 
 
-forwardEpilog = unwrap("""Options marked with (f) are forwarded to the next subcommand if multiple subcommands
-                are chained in the same command execution. Previous values may be overridden by passing new
-                option values into the next subcommand.""")
-
-buildEpilog = unwrap("""Notes:
+epilog = unwrap("""Notes:
 
 --task, --delete, --config, --config-file, and --instrument action options can
 appear multiple times; all values are used, in order left to right.
@@ -51,10 +45,6 @@ distributed among multiple lines (e.g. one option per line). Data after # is
 treated as a comment and ignored. Blank lines and lines starting with # are
 ignored.)
 """)
-
-qgraphEpilog = forwardEpilog
-
-runEpilog = forwardEpilog
 
 
 def _doBuild(ctx, **kwargs):
@@ -76,9 +66,8 @@ def _doBuild(ctx, **kwargs):
     return cli_handle_exception(script.build, **kwargs)
 
 
-@click.command(cls=MWCommand, epilog=buildEpilog, short_help="Build pipeline definition.")
+@click.command(cls=PipetaskCommand, epilog=epilog, short_help="Build pipeline definition.")
 @click.pass_context
-@dafButlerOpts.log_level_option()
 @ctrlMpExecOpts.show_option()
 @ctrlMpExecOpts.pipeline_build_options()
 @option_section(sectionText="")
@@ -91,9 +80,8 @@ def build(ctx, **kwargs):
     _doBuild(ctx, **kwargs)
 
 
-@click.command(cls=MWCommand, epilog=qgraphEpilog)
+@click.command(cls=PipetaskCommand, epilog=epilog)
 @click.pass_context
-@dafButlerOpts.log_level_option()
 @ctrlMpExecOpts.show_option()
 @ctrlMpExecOpts.pipeline_build_options()
 @ctrlMpExecOpts.qgraph_options()
@@ -107,9 +95,8 @@ def qgraph(ctx, **kwargs):
     cli_handle_exception(script.qgraph, pipelineObj=pipeline, **kwargs)
 
 
-@click.command(cls=MWCommand, epilog=runEpilog)
+@click.command(cls=PipetaskCommand, epilog=epilog)
 @click.pass_context
-@dafButlerOpts.log_level_option()
 @ctrlMpExecOpts.debug_option()
 @ctrlMpExecOpts.show_option()
 @ctrlMpExecOpts.pipeline_build_options()

--- a/python/lsst/ctrl/mpexec/cli/script/build.py
+++ b/python/lsst/ctrl/mpexec/cli/script/build.py
@@ -21,12 +21,11 @@
 
 from types import SimpleNamespace
 
-from lsst.daf.butler.cli.cliLog import CliLog
 from ... import CmdLineFwk
 from ..utils import _PipelineAction
 
 
-def build(order_pipeline, pipeline, pipeline_actions, pipeline_dot, save_pipeline, show, log_level, **kwargs):
+def build(order_pipeline, pipeline, pipeline_actions, pipeline_dot, save_pipeline, show, **kwargs):
     """Implements the command line interface `pipetask build` subcommand,
     should only be called by command line tools and unit test code that tests
     this function.
@@ -51,11 +50,6 @@ def build(order_pipeline, pipeline, pipeline_actions, pipeline_dot, save_pipelin
         Path location for storing resulting pipeline definition in YAML format.
     show : `list` [`str`]
         Descriptions of what to dump to stdout.
-    log_level : `list` of `tuple`
-        Per-component logging levels, each item in the list is a tuple
-        (component, level), `component` is a logger name or an empty string
-        or `None` for root logger, `level` is a logging level name, one of
-        CRITICAL, ERROR, WARNING, INFO, DEBUG (case insensitive).
     kwargs : `dict` [`str`, `str`]
         Ignored; click commands may accept options for more than one script
         function and pass all the option kwargs to each of the script functions
@@ -77,9 +71,6 @@ def build(order_pipeline, pipeline, pipeline_actions, pipeline_dot, save_pipelin
     # but we need a list of _PipelineAction.
     if isinstance(pipeline_actions, _PipelineAction):
         pipeline_actions = (pipeline_actions,)
-
-    if log_level is not None:
-        CliLog.setLogLevels(log_level)
 
     args = SimpleNamespace(pipeline=pipeline,
                            pipeline_actions=pipeline_actions,

--- a/python/lsst/ctrl/mpexec/cli/script/qgraph.py
+++ b/python/lsst/ctrl/mpexec/cli/script/qgraph.py
@@ -22,13 +22,12 @@
 import logging
 from types import SimpleNamespace
 
-from lsst.daf.butler.cli.cliLog import CliLog
 from ... import CmdLineFwk
 
 _log = logging.getLogger(__name__.partition(".")[2])
 
 
-def qgraph(pipelineObj, log_level, qgraph, skip_existing, save_qgraph, save_single_quanta, qgraph_dot,
+def qgraph(pipelineObj, qgraph, skip_existing, save_qgraph, save_single_quanta, qgraph_dot,
            butler_config, input, output, output_run, extend_run, replace_run, prune_replaced, data_query,
            show, **kwargs):
     """Implements the command line interface `pipetask qgraph` subcommand,
@@ -40,11 +39,6 @@ def qgraph(pipelineObj, log_level, qgraph, skip_existing, save_qgraph, save_sing
     pipelineObj : `pipe.base.Pipeline` or None.
         The pipeline object used to generate a qgraph. If this is not `None`
         then `qgraph` should be `None`.
-    log_level : `list` of `tuple`
-        per-component logging levels, each item in the list is a tuple
-        (component, level), `component` is a logger name or an empty string
-        or `None` for root logger, `level` is a logging level name, one of
-        CRITICAL, ERROR, WARNING, INFO, DEBUG (case insensitive).
     qgraph : `str` or `None`
         Path location for a serialized quantum graph definition as a pickle
         file. If this option is not None then `pipeline` should be `None`.
@@ -111,9 +105,6 @@ def qgraph(pipelineObj, log_level, qgraph, skip_existing, save_qgraph, save_sing
     qgraph : `lsst.pipe.base.QuantumGraph`
         The qgraph object that was created.
     """
-    if log_level is not None:
-        CliLog.setLogLevels(log_level)
-
     args = SimpleNamespace(qgraph=qgraph,
                            save_qgraph=save_qgraph,
                            save_single_quanta=save_single_quanta,

--- a/python/lsst/ctrl/mpexec/cli/script/run.py
+++ b/python/lsst/ctrl/mpexec/cli/script/run.py
@@ -22,7 +22,6 @@
 import logging
 from types import SimpleNamespace
 
-from lsst.daf.butler.cli.cliLog import CliLog
 from ... import CmdLineFwk, TaskFactory
 
 _log = logging.getLogger(__name__.partition(".")[2])
@@ -31,7 +30,6 @@ _log = logging.getLogger(__name__.partition(".")[2])
 def run(do_raise,
         graph_fixup,
         init_only,
-        log_level,
         no_versions,
         processes,
         profile,
@@ -66,11 +64,6 @@ def run(do_raise,
     init_only : `bool`
         If true, do not actually run; just register dataset types and/or save
         init outputs.
-    log_level : `list` of `tuple`
-        per-component logging levels, each item in the list is a tuple
-        (component, level), `component` is a logger name or an empty string
-        or `None` for root logger, `level` is a logging level name, one of
-        CRITICAL, ERROR, WARNING, INFO, DEBUG (case insensitive).
     no_versions : `bool`
         If true, do not save or check package versions.
     processes : `int`
@@ -142,10 +135,6 @@ def run(do_raise,
         function and pass all the option kwargs to each of the script functions
         which ingore these unused kwargs.
     """
-
-    if log_level is not None:
-        CliLog.setLogLevels(log_level)
-
     args = SimpleNamespace(do_raise=do_raise,
                            graph_fixup=graph_fixup,
                            init_only=init_only,

--- a/python/lsst/ctrl/mpexec/cli/utils.py
+++ b/python/lsst/ctrl/mpexec/cli/utils.py
@@ -24,6 +24,7 @@ import collections
 import re
 
 from lsst.daf.butler.cli.opt import (config_file_option, config_option)
+from lsst.daf.butler.cli.utils import MWCommand
 from lsst.obs.base.cli.opt import instrument_option
 from .opt import (delete_option,
                   task_option)
@@ -137,3 +138,9 @@ def makePipelineActions(args,
         elif args[i] in instrumentFlags:
             pipelineActions.append(_ACTION_ADD_INSTRUMENT(args[i+1]))
     return pipelineActions
+
+
+class PipetaskCommand(MWCommand):
+    """Command subclass with pipetask-command specific overrides."""
+
+    extra_epilog = "See 'pipetask --help' for more options."


### PR DESCRIPTION
PipetaskCommand class allows pipetask-specific overrides of
subcommand behaviors.
This adds a comment to the end of every subcommand's help text,
that more options are available using "pipetask --help"

Removes the --log-level option from subcommands.

There was other help text in the epilog that was specific to
prototype development of chained subcommands, and should have
been removed when we did not use that feature. It is now
removed.