### PR TITLE
DM-27118: Add support for spawn start method

### DIFF
--- a/python/lsst/ctrl/mpexec/cli/opt/optionGroups.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/optionGroups.py
@@ -106,6 +106,7 @@ class execution_options(OptionGroup):  # noqa: N801
             ctrlMpExecOpts.do_raise_option(),
             ctrlMpExecOpts.profile_option(),
             dafButlerOpts.processes_option(),
+            ctrlMpExecOpts.start_method_option(),
             ctrlMpExecOpts.timeout_option(),
             ctrlMpExecOpts.fail_fast_option(),
             ctrlMpExecOpts.graph_fixup_option()]

--- a/python/lsst/ctrl/mpexec/cli/opt/options.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/options.py
@@ -230,6 +230,13 @@ task_option = MWOptionDecorator("-t", "--task",
 timeout_option = MWOptionDecorator("--timeout",
                                    help="Timeout for multiprocessing; maximum wall time (sec).")
 
+
+start_method_option = MWOptionDecorator("--start-method",
+                                        default=None,
+                                        type=click.Choice(["spawn", "fork", "forkserver"]),
+                                        help="Multiprocessing start method, default is platform-specific.")
+
+
 fail_fast_option = MWOptionDecorator("--fail-fast",
                                      help=unwrap("""Stop processing at first error, default is to process
                                                  as many tasks as possible."""),

--- a/python/lsst/ctrl/mpexec/cli/script/run.py
+++ b/python/lsst/ctrl/mpexec/cli/script/run.py
@@ -32,6 +32,7 @@ def run(do_raise,
         init_only,
         no_versions,
         processes,
+        start_method,
         profile,
         qgraphObj,
         register_dataset_types,
@@ -68,6 +69,9 @@ def run(do_raise,
         If true, do not save or check package versions.
     processes : `int`
         The number of processes to use.
+    start_method : `str` or `None`
+        Start method from `multiprocessing` module, `None` selects the best
+        one for current platform.
     profile : `str`
         File name to dump cProfile information to.
     qgraphObj : `lsst.pipe.base.QuantumGraph`
@@ -140,6 +144,7 @@ def run(do_raise,
                            init_only=init_only,
                            no_versions=no_versions,
                            processes=processes,
+                           start_method=start_method,
                            profile=profile,
                            skip_init_writes=skip_init_writes,
                            timeout=timeout,

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -639,6 +639,7 @@ class CmdLineFwk:
                                                     enableLsstDebug=args.enableLsstDebug)
             timeout = self.MP_TIMEOUT if args.timeout is None else args.timeout
             executor = MPGraphExecutor(numProc=args.processes, timeout=timeout,
+                                       startMethod=args.start_method,
                                        quantumExecutor=quantumExecutor,
                                        failFast=args.fail_fast,
                                        executionGraphFixup=graphFixup)

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -31,7 +31,6 @@ import argparse
 import datetime
 import fnmatch
 import logging
-import os
 import re
 import sys
 from typing import List, Optional, Tuple
@@ -48,7 +47,6 @@ from lsst.daf.butler import (
     Registry,
 )
 from lsst.daf.butler.registry import MissingCollectionError
-import lsst.log
 import lsst.pex.config as pexConfig
 from lsst.pipe.base import GraphBuilder, Pipeline, QuantumGraph
 from .dotTools import graph2dot, pipeline2dot
@@ -62,15 +60,6 @@ from lsst.utils import doImport
 # ----------------------------------
 #  Local non-exported definitions --
 # ----------------------------------
-
-# logging properties
-_LOG_PROP = """\
-log4j.rootLogger=INFO, A1
-log4j.appender.A1=ConsoleAppender
-log4j.appender.A1.Target=System.err
-log4j.appender.A1.layout=PatternLayout
-log4j.appender.A1.layout.ConversionPattern={}
-"""
 
 _LOG = logging.getLogger(__name__.partition(".")[2])
 
@@ -440,48 +429,6 @@ class CmdLineFwk:
 
     def __init__(self):
         pass
-
-    @staticmethod
-    def configLog(longlog, logLevels):
-        """Configure logging system.
-
-        Parameters
-        ----------
-        longlog : `bool`
-            If True then make log messages appear in "long format"
-        logLevels : `list` of `tuple`
-            per-component logging levels, each item in the list is a tuple
-            (component, level), `component` is a logger name or `None` for root
-            logger, `level` is a logging level name ('DEBUG', 'INFO', etc.)
-        """
-        if longlog:
-            message_fmt = "%-5p %d{yyyy-MM-ddTHH:mm:ss.SSSZ} %c (%X{LABEL})(%F:%L)- %m%n"
-        else:
-            message_fmt = "%c %p: %m%n"
-
-        # Initialize global logging config. Skip if the env var LSST_LOG_CONFIG exists.
-        # The file it points to would already configure lsst.log.
-        if not os.path.isfile(os.environ.get("LSST_LOG_CONFIG", "")):
-            lsst.log.configure_prop(_LOG_PROP.format(message_fmt))
-
-        # Forward all Python logging to lsst.log
-        lgr = logging.getLogger()
-        lgr.setLevel(logging.INFO)  # same as in log4cxx config above
-        lgr.addHandler(lsst.log.LogHandler())
-
-        # also capture warnings and send them to logging
-        logging.captureWarnings(True)
-
-        # configure individual loggers
-        for component, level in logLevels:
-            level = getattr(lsst.log.Log, level.upper(), None)
-            if level is not None:
-                # set logging level for lsst.log
-                logger = lsst.log.Log.getLogger(component or "")
-                logger.setLevel(level)
-                # set logging level for Python logging
-                pyLevel = lsst.log.LevelTranslator.lsstLog2logging(level)
-                logging.getLogger(component).setLevel(pyLevel)
 
     def makePipeline(self, args):
         """Build a pipeline from command line arguments.

--- a/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
+++ b/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
@@ -70,6 +70,9 @@ class SingleQuantumExecutor(QuantumExecutor):
         self.clobberPartialOutputs = clobberPartialOutputs
 
     def execute(self, taskDef, quantum, butler):
+
+        startTime = time.time()
+
         # Docstring inherited from QuantumExecutor.execute
         self.setupLogging(taskDef, quantum)
         taskClass, config = taskDef.taskClass, taskDef.config
@@ -98,6 +101,10 @@ class SingleQuantumExecutor(QuantumExecutor):
 
         task = self.makeTask(taskClass, config, butler)
         self.runQuantum(task, quantum, taskDef, butler)
+
+        stopTime = time.time()
+        _LOG.info("Execution of task '%s' on quantum %s took %.3f seconds",
+                  taskDef.label, quantum.dataId, stopTime - startTime)
 
     def setupLogging(self, taskDef, quantum):
         """Configure logging system for execution of this task.
@@ -262,15 +269,9 @@ class SingleQuantumExecutor(QuantumExecutor):
         # Get the input and output references for the task
         inputRefs, outputRefs = taskDef.connections.buildDatasetRefs(quantum)
 
-        startTime = time.time()
-
         # Call task runQuantum() method. Any exception thrown by the task
         # propagates to caller.
         task.runQuantum(butlerQC, inputRefs, outputRefs)
-
-        stopTime = time.time()
-        _LOG.info("Execution of task '%s' on quantum %s took %.3f seconds",
-                  taskDef.label, quantum.dataId, stopTime - startTime)
 
         if taskDef.metadataDatasetName is not None:
             # DatasetRef has to be in the Quantum outputs, can lookup by name


### PR DESCRIPTION
Pipetask has new option --start-method which tkaes the name of the start
method from multiprocessing (spawn, fork, forkserver). Default method is
now set as "spawn" on MacOS and "fork" on Linux. Some care was needed
when unpickling dimensions, this has to be done after unpickling
registry. Unpickling is ordered manually now. As usual logging causes
issues, with spawn it needs to be re-initialized in every child, added
support for recording and replaying configuration (part of that is in
`daf_butler`).