### PR TITLE
DM-27682: Switch quantum graph load/save to using URIs

### DIFF
--- a/python/lsst/ctrl/mpexec/cli/opt/options.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/options.py
@@ -133,8 +133,7 @@ prune_replaced_option = MWOptionDecorator("--prune-replaced",
 qgraph_option = MWOptionDecorator("-g", "--qgraph",
                                   help=unwrap("""Location for a serialized quantum graph definition (pickle
                                               file). If this option is given then all input data options and
-                                              pipeline-building options cannot be used."""),
-                                  type=MWPath(exists=True, file_okay=True, dir_okay=False, readable=True))
+                                              pipeline-building options cannot be used.  Can be a URI."""))
 
 
 qgraph_dot_option = MWOptionDecorator("--qgraph-dot",
@@ -166,16 +165,15 @@ save_pipeline_option = MWOptionDecorator("-s", "--save-pipeline",
                                          type=MWPath(dir_okay=False, file_okay=True, writable=True))
 
 save_qgraph_option = MWOptionDecorator("-q", "--save-qgraph",
-                                       help=unwrap("""Location for storing a serialized quantum graph
-                                                   definition (pickle file)."""),
-                                       type=MWPath(file_okay=True, dir_okay=False, readable=True))
+                                       help=unwrap("""URI location for storing a serialized quantum graph
+                                                   definition (pickle file)."""))
 
 
 save_single_quanta_option = MWOptionDecorator("--save-single-quanta",
                                               help=unwrap("""Format string of locations for storing individual
                                                           quantum graph definition (pickle files). The curly
                                                           brace {} in the input string will be replaced by a
-                                                          quantum number."""))
+                                                          quantum number. Can be a URI."""))
 
 
 show_option = MWOptionDecorator("--show",

--- a/python/lsst/ctrl/mpexec/cli/script/qgraph.py
+++ b/python/lsst/ctrl/mpexec/cli/script/qgraph.py
@@ -40,17 +40,17 @@ def qgraph(pipelineObj, qgraph, skip_existing, save_qgraph, save_single_quanta, 
         The pipeline object used to generate a qgraph. If this is not `None`
         then `qgraph` should be `None`.
     qgraph : `str` or `None`
-        Path location for a serialized quantum graph definition as a pickle
+        URI location for a serialized quantum graph definition as a pickle
         file. If this option is not None then `pipeline` should be `None`.
     skip_existing : `bool`
         If all Quantum outputs already exist in the output RUN collection then
         that Quantum will be excluded from the QuantumGraph. Will only be used
         if `extend_run` flag is set.
     save_qgraph : `str` or `None`
-        Path location for storing a serialized quantum graph definition as a
+        URI location for storing a serialized quantum graph definition as a
         pickle file.
     save_single_quanta : `str` or `None`
-        Format string of locations for storing individual quantum graph
+        Format string of URI locations for storing individual quantum graph
         definition (pickle files). The curly brace {} in the input string will
         be replaced by a quantum number.
     qgraph_dot : `str` or `None`

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -502,9 +502,7 @@ class CmdLineFwk:
         registry, collections, run = _ButlerFactory.makeRegistryAndCollections(args)
 
         if args.qgraph:
-
-            with open(args.qgraph, 'rb') as pickleFile:
-                qgraph = QuantumGraph.load(pickleFile, registry.dimensions)
+            qgraph = QuantumGraph.loadUri(args.qgraph, registry.dimensions)
 
             # pipeline can not be provided in this case
             if pipeline:
@@ -527,15 +525,13 @@ class CmdLineFwk:
                       nQuanta, len(qgraph.taskGraph))
 
         if args.save_qgraph:
-            with open(args.save_qgraph, "wb") as pickleFile:
-                qgraph.save(pickleFile)
+            qgraph.saveUri(args.save_qgraph)
 
         if args.save_single_quanta:
             for quantumNode in qgraph:
                 sqgraph = qgraph.subset(quantumNode)
-                filename = args.save_single_quanta.format(quantumNode.nodeId.number)
-                with open(filename, "wb") as pickleFile:
-                    sqgraph.save(pickleFile)
+                uri = args.save_single_quanta.format(quantumNode.nodeId.number)
+                sqgraph.saveUri(uri)
 
         if args.qgraph_dot:
             graph2dot(qgraph, args.qgraph_dot)


### PR DESCRIPTION
In theory this would allow a graph pickle file to be read from S3.