### PR TITLE
DM-27667: Add pipetask option to execute graph subset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ tests/.tests
 pytest_session.txt
 .cache/
 .pytest_cache
-.coverage
+.coverage*

--- a/python/lsst/ctrl/mpexec/cli/opt/optionGroups.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/optionGroups.py
@@ -72,6 +72,8 @@ class qgraph_options(OptionGroup):  # noqa: N801
         self.decorators = [
             option_section(sectionText="Quantum graph building options:"),
             ctrlMpExecOpts.qgraph_option(),
+            ctrlMpExecOpts.qgraph_id_option(),
+            ctrlMpExecOpts.qgraph_node_id_option(),
             ctrlMpExecOpts.skip_existing_option(),
             ctrlMpExecOpts.save_qgraph_option(),
             ctrlMpExecOpts.save_single_quanta_option(),

--- a/python/lsst/ctrl/mpexec/cli/script/qgraph.py
+++ b/python/lsst/ctrl/mpexec/cli/script/qgraph.py
@@ -27,9 +27,9 @@ from ... import CmdLineFwk
 _log = logging.getLogger(__name__.partition(".")[2])
 
 
-def qgraph(pipelineObj, qgraph, skip_existing, save_qgraph, save_single_quanta, qgraph_dot,
-           butler_config, input, output, output_run, extend_run, replace_run, prune_replaced, data_query,
-           show, **kwargs):
+def qgraph(pipelineObj, qgraph, qgraph_id, qgraph_node_id, skip_existing, save_qgraph, save_single_quanta,
+           qgraph_dot, butler_config, input, output, output_run, extend_run, replace_run, prune_replaced,
+           data_query, show, **kwargs):
     """Implements the command line interface `pipetask qgraph` subcommand,
     should only be called by command line tools and unit test code that test
     this function.
@@ -42,6 +42,12 @@ def qgraph(pipelineObj, qgraph, skip_existing, save_qgraph, save_single_quanta, 
     qgraph : `str` or `None`
         URI location for a serialized quantum graph definition as a pickle
         file. If this option is not None then `pipeline` should be `None`.
+    qgraph_id : `str` or `None`
+        Quantum graph identifier, if specified must match the identifier of the
+        graph loaded from a file. Ignored if graph is not loaded from a file.
+    qgraph_node_id : `list` of `int`, optional
+        Only load a specified set of nodes if graph is loaded from a file,
+        nodes are identified by integer IDs.
     skip_existing : `bool`
         If all Quantum outputs already exist in the output RUN collection then
         that Quantum will be excluded from the QuantumGraph. Will only be used
@@ -106,6 +112,8 @@ def qgraph(pipelineObj, qgraph, skip_existing, save_qgraph, save_single_quanta, 
         The qgraph object that was created.
     """
     args = SimpleNamespace(qgraph=qgraph,
+                           qgraph_id=qgraph_id,
+                           qgraph_node_id=qgraph_node_id,
                            save_qgraph=save_qgraph,
                            save_single_quanta=save_single_quanta,
                            qgraph_dot=qgraph_dot,

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -191,7 +191,7 @@ class _ButlerFactory:
             self.outputRun = _OutputRunCollectionInfo(registry, args.output_run)
         elif self.output is not None:
             if args.extend_run:
-                runName, _ = self.output.chain[0]
+                runName = self.output.chain[0]
             else:
                 runName = "{}/{}".format(self.output, Instrument.makeCollectionTimestamp())
             self.outputRun = _OutputRunCollectionInfo(registry, runName)

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -502,7 +502,10 @@ class CmdLineFwk:
         registry, collections, run = _ButlerFactory.makeRegistryAndCollections(args)
 
         if args.qgraph:
-            qgraph = QuantumGraph.loadUri(args.qgraph, registry.dimensions)
+            # click passes empty tuple as default value for qgraph_node_id
+            nodes = args.qgraph_node_id or None
+            qgraph = QuantumGraph.loadUri(args.qgraph, registry.dimensions,
+                                          nodes=nodes, graphID=args.qgraph_id)
 
             # pipeline can not be provided in this case
             if pipeline:
@@ -521,8 +524,8 @@ class CmdLineFwk:
             warnings.warn("QuantumGraph is empty", stacklevel=2)
             return None
         else:
-            _LOG.info("QuantumGraph contains %d quanta for %d tasks",
-                      nQuanta, len(qgraph.taskGraph))
+            _LOG.info("QuantumGraph contains %d quanta for %d tasks, graph ID: %r",
+                      nQuanta, len(qgraph.taskGraph), qgraph.graphID)
 
         if args.save_qgraph:
             qgraph.saveUri(args.save_qgraph)


### PR DESCRIPTION
New option `--qgraph-node-id` is added which takes a bunch of integers
for node numbers to execute from a full graph. Another new option
`--qgraph-id` can be used to specify graph ID to verify it after loading
from pickle file.