### PR TITLE
Fix confusing message from pipetask run (DM-27840)

### DIFF
--- a/python/lsst/ctrl/mpexec/mpGraphExecutor.py
+++ b/python/lsst/ctrl/mpexec/mpGraphExecutor.py
@@ -268,7 +268,6 @@ class MPGraphExecutor(QuantumGraphExecutor):
             methods = dict(linux="fork", darwin="spawn")
             startMethod = methods.get(sys.platform)
         self.startMethod = startMethod
-        _LOG.info("Using %r for multiprocessing start method", self.startMethod)
 
     def execute(self, graph, butler):
         # Docstring inherited from QuantumGraphExecutor.execute
@@ -343,6 +342,8 @@ class MPGraphExecutor(QuantumGraphExecutor):
         """
 
         disableImplicitThreading()  # To prevent thread contention
+
+        _LOG.debug("Using %r for multiprocessing start method", self.startMethod)
 
         # re-pack input quantum data into jobs list
         jobs = _JobList(graph)


### PR DESCRIPTION
Moved the message to a method which only runs in multiprocessing mode,
changed it to debug instead of info.