### PR TITLE
DM-28598: Fix pipetask command-line utility doc generation.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -3,11 +3,10 @@
 This configuration only affects single-package Sphinx documentation builds.
 """
 
-from documenteer.sphinxconfig.stackconf import build_package_configs
-import lsst.ctrl.mpexec
+from documenteer.conf.pipelinespkg import *  # noqa: F403, import *
 
-
-_g = globals()
-_g.update(build_package_configs(
-    project_name='ctrl_mpexec',
-    version=lsst.ctrl.mpexec.version.__version__))
+project = "ctrl_mpexec"
+html_theme_options["logotext"] = project     # noqa: F405, unknown name
+html_title = project
+html_short_title = project
+doxylink = {}

--- a/doc/lsst.ctrl.mpexec/index.rst
+++ b/doc/lsst.ctrl.mpexec/index.rst
@@ -36,9 +36,10 @@ You can find Jira issues for this module under the `ctrl_mpexec <https://jira.ls
 Command Line Scripts
 ====================
 
-.. click:: lsst.ctrl.mpexec.cli.pipetask:cli
-   :prog: pipetask
-   :show-nested:
+.. toctree::
+   :maxdepth: 1
+
+   pipetask
 
 .. _lsst.ctrl.mpexec-pyapi:
 

--- a/doc/lsst.ctrl.mpexec/index.rst
+++ b/doc/lsst.ctrl.mpexec/index.rst
@@ -18,20 +18,6 @@ lsst.ctrl.mpexec
 .. .. toctree::
 ..    :maxdepth: 1
 
-.. _lsst.ctrl.pipetask-script:
-
-Command Line Scripts
-====================
-
-The `pipetask` command is being ported from an argparse framework to a Click
-framework. During development the command implemented using Click is called
-`pipetask2`. At some point the current `pipetask` command will be removed and
-`pipetask2` will be renamed to `pipetask`.
-
-.. click:: lsst.ctrl.mpexec.cli.pipetask:cli
-   :prog: pipetask2
-   :show-nested:
-
 .. _lsst.ctrl.mpexec-contributing:
 
 Contributing
@@ -44,6 +30,15 @@ You can find Jira issues for this module under the `ctrl_mpexec <https://jira.ls
 
 .. .. toctree::
 ..    :maxdepth: 1
+
+.. _lsst.ctrl.mpexec-script:
+
+Command Line Scripts
+====================
+
+.. click:: lsst.ctrl.mpexec.cli.pipetask:cli
+   :prog: pipetask
+   :show-nested:
 
 .. _lsst.ctrl.mpexec-pyapi:
 

--- a/doc/lsst.ctrl.mpexec/pipetask.rst
+++ b/doc/lsst.ctrl.mpexec/pipetask.rst
@@ -1,0 +1,4 @@
+
+.. click:: lsst.ctrl.mpexec.cli.pipetask:cli
+    :prog: pipetask
+    :show-nested:


### PR DESCRIPTION
The rST content was severely bitrotted.  I'm not sure what was going on with the conf.py, but sphinx couldn't find its click extensions
without this change, which is just mindless cargo-culting from daf_butler.