### PR TITLE
DM-12549: ap_pipe must call AssociationTask in a reproducible order

### DIFF
--- a/python/lsst/ctrl/mpexec/execFixupDataId.py
+++ b/python/lsst/ctrl/mpexec/execFixupDataId.py
@@ -96,7 +96,7 @@ class ExecFixupDataId(ExecutionGraphFixup):
         taskDef = graph.findTaskDefByLabel(self.taskLabel)
         if taskDef is None:
             raise ValueError(f"Cannot find task with label {self.taskLabel}")
-        quanta = list(graph.quantaForTask(taskDef))
+        quanta = list(graph.getNodesForTask(taskDef))
         keyQuanta = defaultdict(list)
         for q in quanta:
             key = self._key(q)


### PR DESCRIPTION
This PR updates the `ExecFixupDataId` class and its unit tests to correct some bit-rotting that occurred since it was first written.