### PR TITLE
DM-12549: ap_pipe must call AssociationTask in a reproducible order

### DIFF
--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -72,7 +72,7 @@ class QuantumMock:
 
     def __hash__(self):
         # dict.__eq__ is order-insensitive
-        return hash(sorted(kv for kv in self.dataId.items()))
+        return hash(tuple(sorted(kv for kv in self.dataId.items())))
 
 
 class QuantumIterDataMock:


### PR DESCRIPTION
This PR fixes a bug introduced in #118, involving a hash function that is not currently used (but could have been) by the code under test.