### PR TITLE
DM-30061: PipelineTasks do not use pipeline label as name

### DIFF
--- a/python/lsst/ctrl/mpexec/preExecInit.py
+++ b/python/lsst/ctrl/mpexec/preExecInit.py
@@ -185,7 +185,11 @@ class PreExecInit:
         """
         _LOG.debug("Will save InitOutputs for all tasks")
         for taskDef in graph.iterTaskGraph():
-            task = self.taskFactory.makeTask(taskDef.taskClass, taskDef.config, None, self.butler)
+            task = self.taskFactory.makeTask(taskDef.taskClass,
+                                             taskDef.label,
+                                             taskDef.config,
+                                             None,
+                                             self.butler)
             for name in taskDef.connections.initOutputs:
                 attribute = getattr(taskDef.connections, name)
                 initOutputVar = getattr(task, name)

--- a/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
+++ b/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
@@ -75,7 +75,7 @@ class SingleQuantumExecutor(QuantumExecutor):
 
         # Docstring inherited from QuantumExecutor.execute
         self.setupLogging(taskDef, quantum)
-        taskClass, config = taskDef.taskClass, taskDef.config
+        taskClass, label, config = taskDef.taskClass, taskDef.label, taskDef.config
 
         # check whether to skip or delete old outputs
         if self.checkExistingOutputs(quantum, butler, taskDef):
@@ -99,7 +99,7 @@ class SingleQuantumExecutor(QuantumExecutor):
         # Ensure that we are executing a frozen config
         config.freeze()
 
-        task = self.makeTask(taskClass, config, butler)
+        task = self.makeTask(taskClass, label, config, butler)
         self.runQuantum(task, quantum, taskDef, butler)
 
         stopTime = time.time()
@@ -185,13 +185,15 @@ class SingleQuantumExecutor(QuantumExecutor):
             # no outputs exist
             return False
 
-    def makeTask(self, taskClass, config, butler):
+    def makeTask(self, taskClass, name, config, butler):
         """Make new task instance.
 
         Parameters
         ----------
         taskClass : `type`
             Sub-class of `~lsst.pipe.base.PipelineTask`.
+        name : `str`
+            Name for this task.
         config : `~lsst.pipe.base.PipelineTaskConfig`
             Configuration object for this task
 
@@ -203,7 +205,7 @@ class SingleQuantumExecutor(QuantumExecutor):
             Data butler.
         """
         # call task factory for that
-        return self.taskFactory.makeTask(taskClass, config, None, butler)
+        return self.taskFactory.makeTask(taskClass, name, config, None, butler)
 
     def updatedQuantumInputs(self, quantum, butler):
         """Update quantum with extra information, returns a new updated Quantum.

--- a/python/lsst/ctrl/mpexec/taskFactory.py
+++ b/python/lsst/ctrl/mpexec/taskFactory.py
@@ -35,13 +35,16 @@ _LOG = logging.getLogger(__name__.partition(".")[2])
 class TaskFactory(BaseTaskFactory):
     """Class instantiating PipelineTasks.
     """
-    def makeTask(self, taskClass, config, overrides, butler):
+    def makeTask(self, taskClass, name, config, overrides, butler):
         """Create new PipelineTask instance from its class.
 
         Parameters
         ----------
         taskClass : type
             PipelineTask class.
+        name : `str` or `None`
+            The name of the new task; if `None` then use
+            ``taskClass._DefaultName``.
         config : `pex.Config` or None
             Configuration object, if ``None`` then use task-defined
             configuration class to create new instance.
@@ -90,6 +93,6 @@ class TaskFactory(BaseTaskFactory):
         config.freeze()
 
         # make task instance
-        task = taskClass(config=config, initInputs=initInputs)
+        task = taskClass(config=config, initInputs=initInputs, name=name)
 
         return task

--- a/tests/test_cmdLineFwk.py
+++ b/tests/test_cmdLineFwk.py
@@ -134,12 +134,12 @@ class TaskFactoryMock(TaskFactory):
         elif taskName == "TaskTwo":
             return TaskTwo, "TaskTwo"
 
-    def makeTask(self, taskClass, config, overrides, butler):
+    def makeTask(self, taskClass, name, config, overrides, butler):
         if config is None:
             config = taskClass.ConfigClass()
             if overrides:
                 overrides.applyTo(config)
-        return taskClass(config=config, butler=butler)
+        return taskClass(config=config, butler=butler, name=name)
 
 
 def _makeArgs(registryConfig=None, **kwargs):


### PR DESCRIPTION
This PR updates `TaskFactory.makeTask` to take a label argument, and updates all internal references.