### PR TITLE
DM-30148: PipelineTasks use wrong label as name

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,3 +1,5 @@
-Copyright 2016 University of Illinois Champaign-Urbana
-Copyright 2016-2018 The Board of Trustees of the Leland Stanford Junior University, through SLAC National Accelerator Laboratory
-Copyright 2018 The Trustees of Princeton University
+Copyright 2016 University of Illinois Board of Trustees
+Copyright 2016-2021 The Board of Trustees of the Leland Stanford Junior University, through SLAC National Accelerator Laboratory
+Copyright 2018-2021 The Trustees of Princeton University
+Copyright 2019-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+Copyright 2021 University of Washington

--- a/python/lsst/ctrl/mpexec/taskFactory.py
+++ b/python/lsst/ctrl/mpexec/taskFactory.py
@@ -35,15 +35,15 @@ _LOG = logging.getLogger(__name__.partition(".")[2])
 class TaskFactory(BaseTaskFactory):
     """Class instantiating PipelineTasks.
     """
-    def makeTask(self, taskClass, name, config, overrides, butler):
+    def makeTask(self, taskClass, label, config, overrides, butler):
         """Create new PipelineTask instance from its class.
 
         Parameters
         ----------
         taskClass : type
             PipelineTask class.
-        name : `str` or `None`
-            The name of the new task; if `None` then use
+        label : `str` or `None`
+            The label of the new task; if `None` then use
             ``taskClass._DefaultName``.
         config : `pex.Config` or None
             Configuration object, if ``None`` then use task-defined
@@ -93,6 +93,6 @@ class TaskFactory(BaseTaskFactory):
         config.freeze()
 
         # make task instance
-        task = taskClass(config=config, initInputs=initInputs, name=name)
+        task = taskClass(config=config, initInputs=initInputs, name=label)
 
         return task

--- a/tests/test_taskFactory.py
+++ b/tests/test_taskFactory.py
@@ -1,0 +1,166 @@
+# This file is part of ctrl_mpexec.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import shutil
+import tempfile
+import unittest
+
+import lsst.afw.table as afwTable
+import lsst.daf.butler.tests as butlerTests
+import lsst.pex.config as pexConfig
+from lsst.pipe.base import PipelineTaskConfig, PipelineTaskConnections
+from lsst.pipe.base.configOverrides import ConfigOverrides
+from lsst.pipe.base import connectionTypes
+
+from lsst.ctrl.mpexec import TaskFactory
+
+
+class FakeConnections(PipelineTaskConnections, dimensions=set()):
+    initInput = connectionTypes.InitInput(name="fakeInitInput", doc="", storageClass="SourceCatalog")
+    initOutput = connectionTypes.InitOutput(name="fakeInitOutput", doc="", storageClass="SourceCatalog")
+    input = connectionTypes.Input(name="fakeInput", doc="", storageClass="SourceCatalog", dimensions=set())
+    output = connectionTypes.Output(name="fakeOutput", doc="", storageClass="SourceCatalog", dimensions=set())
+
+
+class FakeConfig(PipelineTaskConfig, pipelineConnections=FakeConnections):
+    widget = pexConfig.Field(dtype=float, doc="")
+
+
+def mockTaskClass():
+    """A class placeholder that records calls to __call__.
+    """
+    mock = unittest.mock.Mock(__name__="_TaskMock", _DefaultName="FakeTask", ConfigClass=FakeConfig)
+    return mock
+
+
+class TaskFactoryTestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        tmp = tempfile.mkdtemp()
+        cls.addClassCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        cls.repo = butlerTests.makeTestRepo(tmp)
+        butlerTests.addDatasetType(cls.repo, "fakeInitInput", set(), "SourceCatalog")
+        butlerTests.addDatasetType(cls.repo, "fakeInitOutput", set(), "SourceCatalog")
+        butlerTests.addDatasetType(cls.repo, "fakeInput", set(), "SourceCatalog")
+        butlerTests.addDatasetType(cls.repo, "fakeOutput", set(), "SourceCatalog")
+
+    def setUp(self):
+        super().setUp()
+
+        self.factory = TaskFactory()
+        self.constructor = mockTaskClass()
+
+    @staticmethod
+    def _alteredConfig():
+        config = FakeConfig()
+        config.widget = 42.0
+        return config
+
+    @staticmethod
+    def _overrides():
+        overrides = ConfigOverrides()
+        overrides.addValueOverride("widget", -1.0)
+        return overrides
+
+    @staticmethod
+    def _dummyCatalog():
+        schema = afwTable.SourceTable.makeMinimalSchema()
+        return afwTable.SourceCatalog(schema)
+
+    def _tempButler(self):
+        butler = butlerTests.makeTestCollection(self.repo, uniqueId=self.id())
+        catalog = self._dummyCatalog()
+        butler.put(catalog, "fakeInitInput")
+        butler.put(catalog, "fakeInitOutput")
+        butler.put(catalog, "fakeInput")
+        butler.put(catalog, "fakeOutput")
+        return butler
+
+    def testOnlyMandatoryArg(self):
+        self.factory.makeTask(taskClass=self.constructor, name=None, config=None,
+                              overrides=None, butler=None)
+        self.constructor.assert_called_with(config=FakeConfig(), initInputs=None, name=None)
+
+    @unittest.expectedFailure
+    def testAllArgs(self):
+        butler = self._tempButler()
+        self.factory.makeTask(taskClass=self.constructor, name="no-name", config=self._alteredConfig(),
+                              overrides=self._overrides(), butler=butler)
+        catalog = butler.get("fakeInitInput")  # Copies of _dummyCatalog are identical but not equal
+        # When config passed in, overrides ignored
+        self.constructor.assert_called_with(config=self._alteredConfig(),
+                                            initInputs={'initInput': catalog},
+                                            name="no-name")
+
+    # Can't test all 14 remaining combinations, but the 6 pairs should be enough coverage
+
+    def testNameConfig(self):
+        self.factory.makeTask(taskClass=self.constructor, name="no-name", config=self._alteredConfig(),
+                              overrides=None, butler=None)
+        self.constructor.assert_called_with(config=self._alteredConfig(), initInputs=None, name="no-name")
+
+    def testNameOverrides(self):
+        self.factory.makeTask(taskClass=self.constructor, name="no-name", config=None,
+                              overrides=self._overrides(), butler=None)
+        config = FakeConfig()
+        self._overrides().applyTo(config)
+        self.constructor.assert_called_with(config=config, initInputs=None, name="no-name")
+
+    @unittest.expectedFailure
+    def testNameButler(self):
+        butler = self._tempButler()
+        self.factory.makeTask(taskClass=self.constructor, name="no-name", config=None,
+                              overrides=None, butler=butler)
+        catalog = butler.get("fakeInitInput")  # Copies of _dummyCatalog are identical but not equal
+        self.constructor.assert_called_with(config=FakeConfig(),
+                                            initInputs={'initInput': catalog},
+                                            name="no-name")
+
+    def testConfigOverrides(self):
+        self.factory.makeTask(taskClass=self.constructor, name=None, config=self._alteredConfig(),
+                              overrides=self._overrides(), butler=None)
+        # When config passed in, overrides ignored
+        self.constructor.assert_called_with(config=self._alteredConfig(), initInputs=None, name=None)
+
+    @unittest.expectedFailure
+    def testConfigButler(self):
+        butler = self._tempButler()
+        self.factory.makeTask(taskClass=self.constructor, name=None, config=self._alteredConfig(),
+                              overrides=None, butler=butler)
+        catalog = butler.get("fakeInitInput")  # Copies of _dummyCatalog are identical but not equal
+        self.constructor.assert_called_with(config=self._alteredConfig(),
+                                            initInputs={'initInput': catalog},
+                                            name=None)
+
+    @unittest.expectedFailure
+    def testOverridesButler(self):
+        butler = self._tempButler()
+        self.factory.makeTask(taskClass=self.constructor, name=None, config=None,
+                              overrides=self._overrides(), butler=butler)
+        config = FakeConfig()
+        self._overrides().applyTo(config)
+        catalog = butler.get("fakeInitInput")  # Copies of _dummyCatalog are identical but not equal
+        self.constructor.assert_called_with(config=config,
+                                            initInputs={'initInput': catalog},
+                                            name=None)

--- a/tests/test_taskFactory.py
+++ b/tests/test_taskFactory.py
@@ -98,14 +98,13 @@ class TaskFactoryTestCase(unittest.TestCase):
         return butler
 
     def testOnlyMandatoryArg(self):
-        self.factory.makeTask(taskClass=self.constructor, name=None, config=None,
+        self.factory.makeTask(taskClass=self.constructor, label=None, config=None,
                               overrides=None, butler=None)
         self.constructor.assert_called_with(config=FakeConfig(), initInputs=None, name=None)
 
-    @unittest.expectedFailure
     def testAllArgs(self):
         butler = self._tempButler()
-        self.factory.makeTask(taskClass=self.constructor, name="no-name", config=self._alteredConfig(),
+        self.factory.makeTask(taskClass=self.constructor, label="no-name", config=self._alteredConfig(),
                               overrides=self._overrides(), butler=butler)
         catalog = butler.get("fakeInitInput")  # Copies of _dummyCatalog are identical but not equal
         # When config passed in, overrides ignored
@@ -116,21 +115,20 @@ class TaskFactoryTestCase(unittest.TestCase):
     # Can't test all 14 remaining combinations, but the 6 pairs should be enough coverage
 
     def testNameConfig(self):
-        self.factory.makeTask(taskClass=self.constructor, name="no-name", config=self._alteredConfig(),
+        self.factory.makeTask(taskClass=self.constructor, label="no-name", config=self._alteredConfig(),
                               overrides=None, butler=None)
         self.constructor.assert_called_with(config=self._alteredConfig(), initInputs=None, name="no-name")
 
     def testNameOverrides(self):
-        self.factory.makeTask(taskClass=self.constructor, name="no-name", config=None,
+        self.factory.makeTask(taskClass=self.constructor, label="no-name", config=None,
                               overrides=self._overrides(), butler=None)
         config = FakeConfig()
         self._overrides().applyTo(config)
         self.constructor.assert_called_with(config=config, initInputs=None, name="no-name")
 
-    @unittest.expectedFailure
     def testNameButler(self):
         butler = self._tempButler()
-        self.factory.makeTask(taskClass=self.constructor, name="no-name", config=None,
+        self.factory.makeTask(taskClass=self.constructor, label="no-name", config=None,
                               overrides=None, butler=butler)
         catalog = butler.get("fakeInitInput")  # Copies of _dummyCatalog are identical but not equal
         self.constructor.assert_called_with(config=FakeConfig(),
@@ -138,25 +136,23 @@ class TaskFactoryTestCase(unittest.TestCase):
                                             name="no-name")
 
     def testConfigOverrides(self):
-        self.factory.makeTask(taskClass=self.constructor, name=None, config=self._alteredConfig(),
+        self.factory.makeTask(taskClass=self.constructor, label=None, config=self._alteredConfig(),
                               overrides=self._overrides(), butler=None)
         # When config passed in, overrides ignored
         self.constructor.assert_called_with(config=self._alteredConfig(), initInputs=None, name=None)
 
-    @unittest.expectedFailure
     def testConfigButler(self):
         butler = self._tempButler()
-        self.factory.makeTask(taskClass=self.constructor, name=None, config=self._alteredConfig(),
+        self.factory.makeTask(taskClass=self.constructor, label=None, config=self._alteredConfig(),
                               overrides=None, butler=butler)
         catalog = butler.get("fakeInitInput")  # Copies of _dummyCatalog are identical but not equal
         self.constructor.assert_called_with(config=self._alteredConfig(),
                                             initInputs={'initInput': catalog},
                                             name=None)
 
-    @unittest.expectedFailure
     def testOverridesButler(self):
         butler = self._tempButler()
-        self.factory.makeTask(taskClass=self.constructor, name=None, config=None,
+        self.factory.makeTask(taskClass=self.constructor, label=None, config=None,
                               overrides=self._overrides(), butler=butler)
         config = FakeConfig()
         self._overrides().applyTo(config)


### PR DESCRIPTION
This PR fixes a name collision inadvertently introduced in #122, and adds unit tests to catch similar bugs in the future.