### PR TITLE
Dm-31054 Fix issue running Quantum when inputs are missing

### DIFF
--- a/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
+++ b/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
@@ -29,6 +29,7 @@ import logging
 from itertools import chain
 import sys
 import time
+from typing import List
 
 # -----------------------------
 #  Imports for other modules --
@@ -44,7 +45,7 @@ from lsst.pipe.base import (
     RepeatableQuantumError,
     logInfo,
 )
-from lsst.daf.butler import Quantum, ButlerMDC
+from lsst.daf.butler import Quantum, ButlerMDC, NamedKeyDict, DatasetRef, DatasetType
 
 # ----------------------------------
 #  Local non-exported definitions --
@@ -289,7 +290,7 @@ class SingleQuantumExecutor(QuantumExecutor):
                     resolvedRef = butler.registry.findDataset(ref.datasetType, ref.dataId,
                                                               collections=butler.collections)
                     if resolvedRef is None:
-                        _LOG.debug("No dataset found for %s", ref)
+                        _LOG.info("No dataset found for %s", ref)
                         continue
                     else:
                         _LOG.debug("Updated dataset ID for %s", ref)
@@ -310,6 +311,7 @@ class SingleQuantumExecutor(QuantumExecutor):
         # generation, because a task shouldn't care whether an input is missing
         # because some previous task didn't produce it, or because it just
         # wasn't there during QG generation.
+        updatedInputs = NamedKeyDict[DatasetType, List[DatasetRef]](updatedInputs.items())
         helper = AdjustQuantumHelper(updatedInputs, quantum.outputs)
         if anyChanges:
             helper.adjust_in_place(taskDef.connections, label=taskDef.label, data_id=quantum.dataId)


### PR DESCRIPTION
The recent NoWorkFound changes were intended to let a Quantum
continue to run if some of its inputs were missing as long as
enough inputs were present. However, there was a bug related
to wrong dataset types and use of defaultdict that caused the
system to always think NO inputs were present if any were
missing. This fixes that.

For those interested, adjustQuantum on a connections class indexes
things by dataset type name, a string. Most other paces use
DatasetType object in mappings. This is not a problem with
NameDict containers because they know how to translate. However in
this case a defaultdict was used to construct the mapping, and the
keys were all DatasetTypes.

Then this was passed through to update the Quantum and adjust it.
Because the container type was still defaultdict, when the updater
indexed with dataset type names (str) it created a new entry in the
defaultdict that was empty, instead of finding the entry associated
with the DatasetType that had the corresponding name.

This only triggered if there was at least one missing input, so in
normal operations everything worked as expected. A subsequent
container was then passed into adjustQuantum that had no datasetRefs
(because the defaultdict created a new empty entry) and the method
rightly said 0 is less than 1 required ref and raised a NoWorkFound.

Solution was to change to the proper NamedDict object before calling
into the update code in pipe_base.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
