### PR TITLE
DM-27492: Improvements to pipetask execution options

### DIFF
--- a/doc/changes/DM-27492.feature.md
+++ b/doc/changes/DM-27492.feature.md
@@ -1,0 +1,8 @@
+Several improvements in `pipetask` execution options:
+- New option `--skip-existing-in` which takes collection names(s), if output
+  datasets already exist in those collections corresponding quanta is skipped.
+- A `--skip-existing` option is now equivalent to appending output run
+  collection to the `--skip-existing-in` list.
+- An `--extend-run` option implicitly enables `--skip-existing` option.
+- A `--prune-replaced=unstore` option only removes regular output datasets;
+  InitOutputs, task configs, and package versions are not removed.

--- a/python/lsst/ctrl/mpexec/cli/opt/optionGroups.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/optionGroups.py
@@ -67,6 +67,7 @@ class qgraph_options(OptionGroup):  # noqa: N801
             ctrlMpExecOpts.qgraph_option(),
             ctrlMpExecOpts.qgraph_id_option(),
             ctrlMpExecOpts.qgraph_node_id_option(),
+            ctrlMpExecOpts.skip_existing_in_option(),
             ctrlMpExecOpts.skip_existing_option(),
             ctrlMpExecOpts.clobber_outputs_option(),
             ctrlMpExecOpts.save_qgraph_option(),

--- a/python/lsst/ctrl/mpexec/cli/opt/options.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/options.py
@@ -85,7 +85,7 @@ extend_run_option = MWOptionDecorator("--extend-run",
                                       help=unwrap("""Instead of creating a new RUN collection, insert datasets
                                                   into either the one given by --output-run (if provided) or
                                                   the first child collection of --output (which must be of
-                                                  type RUN)."""),
+                                                  type RUN). This also enables --skip-existing option."""),
                                       is_flag=True)
 
 

--- a/python/lsst/ctrl/mpexec/cli/opt/options.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/options.py
@@ -84,7 +84,7 @@ do_raise_option = MWOptionDecorator("--do-raise",
 extend_run_option = MWOptionDecorator("--extend-run",
                                       help=unwrap("""Instead of creating a new RUN collection, insert datasets
                                                   into either the one given by --output-run (if provided) or
-                                                  the first child collection of - -output(which must be of
+                                                  the first child collection of --output (which must be of
                                                   type RUN)."""),
                                       is_flag=True)
 

--- a/python/lsst/ctrl/mpexec/cli/opt/options.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/options.py
@@ -244,19 +244,37 @@ show_option = MWOptionDecorator("--show",
                                 multiple=True)
 
 
-skip_existing_option = MWOptionDecorator("--skip-existing",
-                                         help=unwrap("""If all Quantum outputs already exist in the output RUN
-                                                     collection then that Quantum will be excluded from the
-                                                     QuantumGraph. Requires the 'run` command's `--extend-run`
-                                                     flag to be set."""),
-                                         is_flag=True)
+skip_existing_in_option = MWOptionDecorator(
+    "--skip-existing-in",
+    callback=split_commas,
+    default=None,
+    metavar="COLLECTION",
+    multiple=True,
+    help=unwrap(
+        """If all Quantum outputs already exist in the specified list of
+        collections then that Quantum will be excluded from the QuantumGraph.
+        """
+    )
+)
+
+
+skip_existing_option = MWOptionDecorator(
+    "--skip-existing",
+    is_flag=True,
+    help=unwrap(
+        """This option is equivalent to --skip-existing-in with the name of
+        the output RUN collection. If both --skip-existing-in and
+        --skip-existing are given then output RUN collection is appended to
+        the list of collections."""
+    )
+)
 
 
 clobber_outputs_option = MWOptionDecorator("--clobber-outputs",
                                            help=unwrap("""Remove outputs from previous execution of the same
-                                                       quantum before new execution.  If `--skip-existing`
+                                                       quantum before new execution.  If --skip-existing
                                                        is also passed, then only failed quanta will be
-                                                       clobbered. Requires the 'run` command's `--extend-run`
+                                                       clobbered. Requires the 'run' command's --extend-run
                                                        flag to be set."""),
                                            is_flag=True)
 

--- a/python/lsst/ctrl/mpexec/cli/script/qgraph.py
+++ b/python/lsst/ctrl/mpexec/cli/script/qgraph.py
@@ -27,9 +27,10 @@ from ... import CmdLineFwk
 _log = logging.getLogger(__name__.partition(".")[2])
 
 
-def qgraph(pipelineObj, qgraph, qgraph_id, qgraph_node_id, skip_existing, save_qgraph, save_single_quanta,
-           qgraph_dot, butler_config, input, output, output_run, extend_run, replace_run, prune_replaced,
-           data_query, show, save_execution_butler, clobber_execution_butler, clobber_outputs, **kwargs):
+def qgraph(pipelineObj, qgraph, qgraph_id, qgraph_node_id, skip_existing_in, skip_existing, save_qgraph,
+           save_single_quanta, qgraph_dot, butler_config, input, output, output_run, extend_run,
+           replace_run, prune_replaced, data_query, show, save_execution_butler, clobber_execution_butler,
+           clobber_outputs, **kwargs):
     """Implements the command line interface `pipetask qgraph` subcommand,
     should only be called by command line tools and unit test code that test
     this function.
@@ -48,10 +49,12 @@ def qgraph(pipelineObj, qgraph, qgraph_id, qgraph_node_id, skip_existing, save_q
     qgraph_node_id : `list` of `int`, optional
         Only load a specified set of nodes if graph is loaded from a file,
         nodes are identified by integer IDs.
+    skip_existing_in : `list` [ `str` ]
+        Accepts list of collections, if all Quantum outputs already exist in
+        the specified list of collections then that Quantum will be excluded
+        from the QuantumGraph.
     skip_existing : `bool`
-        If all Quantum outputs already exist in the output RUN collection then
-        that Quantum will be excluded from the QuantumGraph. Will only be used
-        if `extend_run` flag is set.
+        Appends output RUN collection to the ``skip_existing_in`` list.
     save_qgraph : `str` or `None`
         URI location for storing a serialized quantum graph definition as a
         pickle file.
@@ -67,10 +70,8 @@ def qgraph(pipelineObj, qgraph, qgraph_id, qgraph_node_id, skip_existing, save_q
         butler/registry config file. If `dict`, `butler_config` is key value
         pairs used to init or update the `lsst.daf.butler.Config` instance. If
         `Config`, it is the object used to configure a Butler.
-    input : `str`
-        Comma-separated names of the input collection(s). Entries may include a
-        colon (:), the first string is a dataset type name that restricts the
-        search in that collection.
+    input : `list` [ `str` ]
+        List of names of the input collection(s).
     output : `str`
         Name of the output CHAINED collection. This may either be an existing
         CHAINED collection to use as both input and output (if `input` is
@@ -136,6 +137,7 @@ def qgraph(pipelineObj, qgraph, qgraph_id, qgraph_node_id, skip_existing, save_q
                            prune_replaced=prune_replaced,
                            data_query=data_query,
                            show=show,
+                           skip_existing_in=skip_existing_in,
                            skip_existing=skip_existing,
                            execution_butler_location=save_execution_butler,
                            clobber_execution_butler=clobber_execution_butler,

--- a/python/lsst/ctrl/mpexec/cli/script/run.py
+++ b/python/lsst/ctrl/mpexec/cli/script/run.py
@@ -46,6 +46,7 @@ def run(do_raise,
         replace_run,
         prune_replaced,
         data_query,
+        skip_existing_in,
         skip_existing,
         debug,
         fail_fast,
@@ -89,10 +90,8 @@ def run(do_raise,
         butler/registry config file. If `dict`, `butler_config` is key value
         pairs used to init or update the `lsst.daf.butler.Config` instance. If
         `Config`, it is the object used to configure a Butler.
-    input : `str`
-        Comma-separated names of the input collection(s). Entries may include a
-        colon (:), the first string is a dataset type name that restricts the
-        search in that collection.
+    input : `list` [ `str` ]
+        List of names of the input collection(s).
     output : `str`
         Name of the output CHAINED collection. This may either be an existing
         CHAINED collection to use as both input and output (if `input` is
@@ -122,10 +121,12 @@ def run(do_raise,
         removing them and the RUN completely ("purge"). Requires `replace_run`.
     data_query : `str`
         User query selection expression.
+    skip_existing_in : `list` [ `str` ]
+        Accepts list of collections, if all Quantum outputs already exist in
+        the specified list of collections then that Quantum will be excluded
+        from the QuantumGraph.
     skip_existing : `bool`
-        If all Quantum outputs already exist in the output RUN collection then
-        that Quantum will be excluded from the QuantumGraph. Requires the 'run`
-        command's `--extend-run` flag to be set.
+        Appends output RUN collection to the ``skip_existing_in`` list.
     debug : `bool`
         If true, enable debugging output using lsstDebug facility (imports
         debug.py).
@@ -159,6 +160,7 @@ def run(do_raise,
                            replace_run=replace_run,
                            prune_replaced=prune_replaced,
                            data_query=data_query,
+                           skip_existing_in=skip_existing_in,
                            skip_existing=skip_existing,
                            enableLsstDebug=debug,
                            fail_fast=fail_fast,

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -627,9 +627,8 @@ class CmdLineFwk:
             except ImportError:
                 _LOG.warn("No 'debug' module found.")
 
-        # --skip-existing should have no effect unless --extend-run is passed
-        # so we make PreExecInit's skipExisting depend on the latter as well.
-        preExecInit = PreExecInit(butler, taskFactory, skipExisting=args.extend_run)
+        # Save all InitOutputs, configs, etc.
+        preExecInit = PreExecInit(butler, taskFactory, extendRun=args.extend_run)
         preExecInit.initialize(graph,
                                saveInitOutputs=not args.skip_init_writes,
                                registerDatasetTypes=args.register_dataset_types,

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -524,6 +524,10 @@ class CmdLineFwk:
             If resulting graph is empty then `None` is returned.
         """
 
+        # make sure that --extend-run always enables --skip-existing
+        if args.extend_run:
+            args.skip_existing = True
+
         registry, collections, run = _ButlerFactory.makeRegistryAndCollections(args)
 
         if args.qgraph:
@@ -604,6 +608,10 @@ class CmdLineFwk:
             Data Butler instance, if not defined then new instance is made
             using command line options.
         """
+        # make sure that --extend-run always enables --skip-existing
+        if args.extend_run:
+            args.skip_existing = True
+
         # make butler instance
         if butler is None:
             butler = _ButlerFactory.makeWriteButler(args)
@@ -621,7 +629,7 @@ class CmdLineFwk:
 
         # --skip-existing should have no effect unless --extend-run is passed
         # so we make PreExecInit's skipExisting depend on the latter as well.
-        preExecInit = PreExecInit(butler, taskFactory, skipExisting=(args.skip_existing and args.extend_run))
+        preExecInit = PreExecInit(butler, taskFactory, skipExisting=args.extend_run)
         preExecInit.initialize(graph,
                                saveInitOutputs=not args.skip_init_writes,
                                registerDatasetTypes=args.register_dataset_types,

--- a/python/lsst/ctrl/mpexec/preExecInit.py
+++ b/python/lsst/ctrl/mpexec/preExecInit.py
@@ -197,7 +197,9 @@ class PreExecInit:
                             raise TypeError(f"Stored initOutput object type {type(objFromStore)} "
                                             f"is different  from task-generated type "
                                             f"{type(initOutputVar)} for task {taskDef}")
-                    except LookupError:
+                    except (LookupError, FileNotFoundError):
+                        # FileNotFoundError likely means execution butler
+                        # where refs do exist but datastore artifacts do not.
                         pass
                 if objFromStore is None:
                     # butler will raise exception if dataset is already there
@@ -242,7 +244,9 @@ class PreExecInit:
                             raise TypeError(
                                 f"Config does not match existing task config {configName!r} in butler; "
                                 "tasks configurations must be consistent within the same run collection")
-                    except LookupError:
+                    except (LookupError, FileNotFoundError):
+                        # FileNotFoundError likely means execution butler
+                        # where refs do exist but datastore artifacts do not.
                         pass
                 if oldConfig is None:
                     # butler will raise exception if dataset is already there
@@ -274,7 +278,9 @@ class PreExecInit:
                 try:
                     oldPackages = self.butler.get(datasetType, dataId, collections=[self.butler.run])
                     _LOG.debug("old packages: %s", oldPackages)
-                except LookupError:
+                except (LookupError, FileNotFoundError):
+                    # FileNotFoundError likely means execution butler where
+                    # refs do exist but datastore artifacts do not.
                     pass
             if oldPackages is not None:
                 # Note that because we can only detect python modules that have

--- a/python/lsst/ctrl/mpexec/preExecInit.py
+++ b/python/lsst/ctrl/mpexec/preExecInit.py
@@ -49,19 +49,19 @@ class PreExecInit:
         Data butler instance.
     taskFactory : `~lsst.pipe.base.TaskFactory`
         Task factory.
-    skipExisting : `bool`, optional
+    extendRun : `bool`, optional
         If `True` then do not try to overwrite any datasets that might exist
         in ``butler.run``; instead compare them when appropriate/possible.  If
         `False`, then any existing conflicting dataset will cause a butler
         exception to be raised.
     """
-    def __init__(self, butler, taskFactory, skipExisting=False):
+    def __init__(self, butler, taskFactory, extendRun=False):
         self.butler = butler
         self.taskFactory = taskFactory
-        self.skipExisting = skipExisting
-        if self.skipExisting and self.butler.run is None:
+        self.extendRun = extendRun
+        if self.extendRun and self.butler.run is None:
             raise RuntimeError(
-                "Cannot perform skipExisting logic unless butler is initialized "
+                "Cannot perform extendRun logic unless butler is initialized "
                 "with a default output RUN collection."
             )
 
@@ -154,14 +154,17 @@ class PreExecInit:
 
         Raises
         ------
+        TypeError
+            Raised if ``extendRun`` is `True` but type of existing object in
+            butler is different from new data.
         Exception
-            Raised if ``skipExisting`` is `False` and datasets already
+            Raised if ``extendRun`` is `False` and datasets already
             exists. Content of a butler collection may be changed if
             exception is raised.
 
         Notes
         -----
-        If ``skipExisting`` is `True` then existing datasets are not
+        If ``extendRun`` is `True` then existing datasets are not
         overwritten, instead we should check that their stored object is
         exactly the same as what we would save at this time. Comparing
         arbitrary types of object is, of course, non-trivial. Current
@@ -182,7 +185,7 @@ class PreExecInit:
                 attribute = getattr(taskDef.connections, name)
                 initOutputVar = getattr(task, name)
                 objFromStore = None
-                if self.skipExisting:
+                if self.extendRun:
                     # check if it is there already
                     _LOG.debug("Retrieving InitOutputs for task=%s key=%s dsTypeName=%s",
                                task, name, attribute.name)
@@ -212,8 +215,11 @@ class PreExecInit:
 
         Raises
         ------
+        TypeError
+            Raised if ``extendRun`` is `True` but existing object in butler is
+            different from new data.
         Exception
-            Raised if ``skipExisting`` is `False` and datasets already exists.
+            Raised if ``extendRun`` is `False` and datasets already exists.
             Content of a butler collection should not be changed if exception
             is raised.
         """
@@ -229,7 +235,7 @@ class PreExecInit:
                 configName = taskDef.configDatasetName
 
                 oldConfig = None
-                if self.skipExisting:
+                if self.extendRun:
                     try:
                         oldConfig = self.butler.get(configName, {}, collections=[self.butler.run])
                         if not taskDef.config.compare(oldConfig, shortcut=False, output=logConfigMismatch):
@@ -253,9 +259,9 @@ class PreExecInit:
 
         Raises
         ------
-        Exception
-            Raised if ``checkExisting`` is ``True`` but versions are not
-            compatible.
+        TypeError
+            Raised if ``extendRun`` is `True` but existing object in butler is
+            different from new data.
         """
         packages = Packages.fromSystem()
         _LOG.debug("want to save packages: %s", packages)
@@ -264,7 +270,7 @@ class PreExecInit:
         oldPackages = None
         # start transaction to rollback any changes on exceptions
         with self.butler.transaction():
-            if self.skipExisting:
+            if self.extendRun:
                 try:
                     oldPackages = self.butler.get(datasetType, dataId, collections=[self.butler.run])
                     _LOG.debug("old packages: %s", oldPackages)

--- a/python/lsst/ctrl/mpexec/preExecInit.py
+++ b/python/lsst/ctrl/mpexec/preExecInit.py
@@ -265,7 +265,7 @@ class PreExecInit:
         """
         packages = Packages.fromSystem()
         _LOG.debug("want to save packages: %s", packages)
-        datasetType = "packages"
+        datasetType = PipelineDatasetTypes.packagesDatasetName
         dataId = {}
         oldPackages = None
         # start transaction to rollback any changes on exceptions

--- a/tests/test_cmdLineFwk.py
+++ b/tests/test_cmdLineFwk.py
@@ -433,7 +433,7 @@ class CmdLineFwkTestCaseWithButler(unittest.TestCase):
             butler_config=self.root,
             input="test",
             output="output",
-            skip_existing=True,
+            skip_existing_in=("test", ),
         )
         butler = makeSimpleButler(self.root, run=args.input, inMemory=False)
         populateButler(
@@ -468,7 +468,7 @@ class CmdLineFwkTestCaseWithButler(unittest.TestCase):
             butler_config=self.root,
             input="test",
             output_run="output/run",
-            skip_existing=True,
+            skip_existing_in=("output/run", ),
         )
         butler = makeSimpleButler(self.root, run=args.input, inMemory=False)
         populateButler(
@@ -534,7 +534,7 @@ class CmdLineFwkTestCaseWithButler(unittest.TestCase):
         butler.pruneDatasets([ref1, ref2], disassociate=True, unstore=True, purge=True)
 
         taskFactory.stopAt = -1
-        args.skip_existing = True
+        args.skip_existing_in = (args.output, )
         args.extend_run = True
         args.no_versions = True
         excRe = "Registry inconsistency while checking for existing outputs.*"

--- a/tests/test_preExecInit.py
+++ b/tests/test_preExecInit.py
@@ -49,24 +49,24 @@ class PreExecInitTestCase(unittest.TestCase):
 
     def test_saveInitOutputs(self):
         taskFactory = AddTaskFactoryMock()
-        for skipExisting in (False, True):
-            with self.subTest(skipExisting=skipExisting):
+        for extendRun in (False, True):
+            with self.subTest(extendRun=extendRun):
                 with temporaryDirectory() as tmpdir:
                     butler, qgraph = makeSimpleQGraph(root=tmpdir)
                     preExecInit = PreExecInit(butler=butler, taskFactory=taskFactory,
-                                              skipExisting=skipExisting)
+                                              extendRun=extendRun)
                     preExecInit.saveInitOutputs(qgraph)
 
     def test_saveInitOutputs_twice(self):
         taskFactory = AddTaskFactoryMock()
-        for skipExisting in (False, True):
-            with self.subTest(skipExisting=skipExisting):
+        for extendRun in (False, True):
+            with self.subTest(extendRun=extendRun):
                 with temporaryDirectory() as tmpdir:
                     butler, qgraph = makeSimpleQGraph(root=tmpdir)
                     preExecInit = PreExecInit(butler=butler, taskFactory=taskFactory,
-                                              skipExisting=skipExisting)
+                                              extendRun=extendRun)
                     preExecInit.saveInitOutputs(qgraph)
-                    if skipExisting:
+                    if extendRun:
                         # will ignore this
                         preExecInit.saveInitOutputs(qgraph)
                     else:
@@ -75,21 +75,21 @@ class PreExecInitTestCase(unittest.TestCase):
                             preExecInit.saveInitOutputs(qgraph)
 
     def test_saveConfigs(self):
-        for skipExisting in (False, True):
-            with self.subTest(skipExisting=skipExisting):
+        for extendRun in (False, True):
+            with self.subTest(extendRun=extendRun):
                 with temporaryDirectory() as tmpdir:
                     butler, qgraph = makeSimpleQGraph(root=tmpdir)
-                    preExecInit = PreExecInit(butler=butler, taskFactory=None, skipExisting=skipExisting)
+                    preExecInit = PreExecInit(butler=butler, taskFactory=None, extendRun=extendRun)
                     preExecInit.saveConfigs(qgraph)
 
     def test_saveConfigs_twice(self):
-        for skipExisting in (False, True):
-            with self.subTest(skipExisting=skipExisting):
+        for extendRun in (False, True):
+            with self.subTest(extendRun=extendRun):
                 with temporaryDirectory() as tmpdir:
                     butler, qgraph = makeSimpleQGraph(root=tmpdir)
-                    preExecInit = PreExecInit(butler=butler, taskFactory=None, skipExisting=skipExisting)
+                    preExecInit = PreExecInit(butler=butler, taskFactory=None, extendRun=extendRun)
                     preExecInit.saveConfigs(qgraph)
-                    if skipExisting:
+                    if extendRun:
                         # will ignore this
                         preExecInit.saveConfigs(qgraph)
                     else:
@@ -98,21 +98,21 @@ class PreExecInitTestCase(unittest.TestCase):
                             preExecInit.saveConfigs(qgraph)
 
     def test_savePackageVersions(self):
-        for skipExisting in (False, True):
-            with self.subTest(skipExisting=skipExisting):
+        for extendRun in (False, True):
+            with self.subTest(extendRun=extendRun):
                 with temporaryDirectory() as tmpdir:
                     butler, qgraph = makeSimpleQGraph(root=tmpdir)
-                    preExecInit = PreExecInit(butler=butler, taskFactory=None, skipExisting=skipExisting)
+                    preExecInit = PreExecInit(butler=butler, taskFactory=None, extendRun=extendRun)
                     preExecInit.savePackageVersions(qgraph)
 
     def test_savePackageVersions_twice(self):
-        for skipExisting in (False, True):
-            with self.subTest(skipExisting=skipExisting):
+        for extendRun in (False, True):
+            with self.subTest(extendRun=extendRun):
                 with temporaryDirectory() as tmpdir:
                     butler, qgraph = makeSimpleQGraph(root=tmpdir)
-                    preExecInit = PreExecInit(butler=butler, taskFactory=None, skipExisting=skipExisting)
+                    preExecInit = PreExecInit(butler=butler, taskFactory=None, extendRun=extendRun)
                     preExecInit.savePackageVersions(qgraph)
-                    if skipExisting:
+                    if extendRun:
                         # If this is the same packages then it should not
                         # attempt to save.
                         preExecInit.savePackageVersions(qgraph)


### PR DESCRIPTION
Several improvements in `pipetask` execution options:
- New option `--skip-existing-in` which takes collection names(s), if output
  datasets already exist in those collections corresponding quanta is skipped.
- A `--skip-existing` option is now equivalent to appending output run
  collection to the `--skip-existing-in` list.
- An `--extend-run` option implicitly enables `--skip-existing` option.
- A `--prune-replaced=unstore` option only removes regular output datasets;
  InitOutputs, task configs, and package versions are not removed.

## Checklist

- [X] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
