### PR TITLE
DM-31384: Add extra information to log record

### DIFF
--- a/doc/changes/DM-31884.feature.rst
+++ b/doc/changes/DM-31884.feature.rst
@@ -1,0 +1,2 @@
+* Add the output run to the log record.
+* Add ``--log-label`` option to ``pipetask`` command to allow extra information to be injected into the log record.

--- a/python/lsst/ctrl/mpexec/cli/pipetask.py
+++ b/python/lsst/ctrl/mpexec/cli/pipetask.py
@@ -22,7 +22,13 @@
 import click
 
 from lsst.daf.butler.cli.butler import LoaderCLI
-from lsst.daf.butler.cli.opt import log_level_option, long_log_option, log_file_option, log_tty_option
+from lsst.daf.butler.cli.opt import (
+    log_level_option,
+    long_log_option,
+    log_file_option,
+    log_tty_option,
+    log_label_option,
+)
 
 
 class PipetaskCLI(LoaderCLI):
@@ -35,7 +41,8 @@ class PipetaskCLI(LoaderCLI):
 @long_log_option()
 @log_file_option()
 @log_tty_option()
-def cli(log_level, long_log, log_file, log_tty):
+@log_label_option()
+def cli(log_level, long_log, log_file, log_tty, log_label):
     # log_level is handled by get_command and list_commands, and is called in
     # one of those functions before this is called.
     pass

--- a/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
+++ b/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
@@ -236,7 +236,7 @@ class SingleQuantumExecutor(QuantumExecutor):
 
         ctx = _LogCaptureFlag()
         try:
-            with ButlerMDC.set_mdc({"LABEL": label}):
+            with ButlerMDC.set_mdc({"LABEL": label, "RUN": butler.run}):
                 yield ctx
         finally:
             # Ensure that the logs are stored in butler.


### PR DESCRIPTION
Requires lsst/daf_butler#557

Adds the output RUN to every record and also now supports the `--log-label` command.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
