### PR TITLE
DM-31691: Fix call to buildExecutionButler.

### DIFF
--- a/doc/changes/DM-31691.bugfix.rst
+++ b/doc/changes/DM-31691.bugfix.rst
@@ -1,0 +1,1 @@
+Include output collection in call to ``buildExecutionButler``.

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -603,7 +603,7 @@ class CmdLineFwk:
                 return newButler
 
             buildExecutionButler(butler, qgraph, args.execution_butler_location, run,
-                                 butlerModifier=builderShim, collections=args.input,
+                                 butlerModifier=builderShim, collections=collections,
                                  clobber=args.clobber_execution_butler)
 
         return qgraph


### PR DESCRIPTION
Include output collection in call to buildExecutionButler.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
