### PR TITLE
DM-31583: Refresh registry caches before running a quantum.

### DIFF
--- a/doc/changes/DM-31583.misc.rst
+++ b/doc/changes/DM-31583.misc.rst
@@ -1,0 +1,3 @@
+Refresh butler caches before executing each quantum.
+
+This may increase contention for database connections when running many jobs against a shared database, but it is needed to avoid lookup failures due stale caches in butler.

--- a/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
+++ b/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
@@ -118,7 +118,7 @@ class SingleQuantumExecutor(QuantumExecutor):
     def execute(self, taskDef, quantum, butler):
         # Docstring inherited from QuantumExecutor.execute
         startTime = time.time()
-
+        butler.registry.refresh()
         with self.captureLogging(taskDef, quantum, butler) as captureLog:
 
             # Save detailed resource usage before task start to metadata.
@@ -391,7 +391,7 @@ class SingleQuantumExecutor(QuantumExecutor):
                     resolvedRef = butler.registry.findDataset(ref.datasetType, ref.dataId,
                                                               collections=butler.collections)
                     if resolvedRef is None:
-                        _LOG.info("No dataset found for %s", ref)
+                        _LOG.info("No dataset found for %s in collections %s", ref, butler.collections)
                         continue
                     else:
                         _LOG.debug("Updated dataset ID for %s", ref)


### PR DESCRIPTION
This is necessary to pick up datasets added to the registry by other processes.  It may temporarily exacerbate problems with connection contention in shared-registry batch, but execution butler should fix that.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
