### PR TITLE
DM-31941: Do not purge datasets when clobbering in execution butler

### DIFF
--- a/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
+++ b/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
@@ -327,7 +327,16 @@ class SingleQuantumExecutor(QuantumExecutor):
                 if self.clobberOutputs:
                     # only prune
                     _LOG.info("Removing partial outputs for task %s: %s", taskDef, existingRefs)
-                    butler.pruneDatasets(existingRefs, disassociate=True, unstore=True, purge=True)
+                    # Do not purge registry records if this looks like
+                    # an execution butler. This ensures that the UUID
+                    # of the dataset doesn't change.
+                    if butler._allow_put_of_predefined_dataset:
+                        purge = False
+                        disassociate = False
+                    else:
+                        purge = True
+                        disassociate = True
+                    butler.pruneDatasets(existingRefs, disassociate=disassociate, unstore=True, purge=purge)
                     return False
                 else:
                     raise RuntimeError(f"Registry inconsistency while checking for existing outputs:"


### PR DESCRIPTION
It's much easier for provenance tracking if the UUID of the dataset always matches the one generated during initial creation of the execution butler. When clobbering the output datasets because of a resubmission of a failed job the pruneDatasets call was purging the records and deleting the files. This results in entirely new UUIDs being used when the new dataset
is put in the butler.  Modify the logic to not purge if it seems that an execution butler is being used.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
