### PR TITLE
DM-31801: Change logger name to retain the lsst. prefix

### DIFF
--- a/python/lsst/ctrl/mpexec/cli/script/qgraph.py
+++ b/python/lsst/ctrl/mpexec/cli/script/qgraph.py
@@ -26,7 +26,7 @@ from ... import CmdLineFwk
 
 from lsst.pipe.base.graphBuilder import DatasetQueryConstraintVariant
 
-_log = logging.getLogger(__name__.partition(".")[2])
+_log = logging.getLogger(__name__)
 
 
 def qgraph(pipelineObj, qgraph, qgraph_id, qgraph_node_id, skip_existing_in, skip_existing, save_qgraph,

--- a/python/lsst/ctrl/mpexec/cli/script/run.py
+++ b/python/lsst/ctrl/mpexec/cli/script/run.py
@@ -24,7 +24,7 @@ from types import SimpleNamespace
 
 from ... import CmdLineFwk, TaskFactory
 
-_log = logging.getLogger(__name__.partition(".")[2])
+_log = logging.getLogger(__name__)
 
 
 def run(do_raise,

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -64,7 +64,7 @@ from lsst.utils import doImport
 #  Local non-exported definitions --
 # ----------------------------------
 
-_LOG = logging.getLogger(__name__.partition(".")[2])
+_LOG = logging.getLogger(__name__)
 
 
 class _OutputChainedCollectionInfo:

--- a/python/lsst/ctrl/mpexec/examples/calexpToCoaddTask.py
+++ b/python/lsst/ctrl/mpexec/examples/calexpToCoaddTask.py
@@ -9,7 +9,7 @@ from lsst.pipe.base import (Struct, PipelineTask, PipelineTaskConfig,
 from lsst.pipe.base import connectionTypes as cT
 import lsstDebug
 
-_LOG = logging.getLogger(__name__.partition(".")[2])
+_LOG = logging.getLogger(__name__)
 
 
 class CalexpToCoaddTaskConnections(PipelineTaskConnections,

--- a/python/lsst/ctrl/mpexec/examples/patchSkyMapTask.py
+++ b/python/lsst/ctrl/mpexec/examples/patchSkyMapTask.py
@@ -7,7 +7,7 @@ from lsst.pipe.base import (Struct, PipelineTask, PipelineTaskConfig,
                             PipelineTaskConnections)
 from lsst.pipe.base import connectionTypes as cT
 
-_LOG = logging.getLogger(__name__.partition(".")[2])
+_LOG = logging.getLogger(__name__)
 
 
 class PatchSkyMapTaskConnections(PipelineTaskConnections,

--- a/python/lsst/ctrl/mpexec/examples/rawToCalexpTask.py
+++ b/python/lsst/ctrl/mpexec/examples/rawToCalexpTask.py
@@ -8,7 +8,7 @@ from lsst.pipe.base import (Struct, PipelineTask, PipelineTaskConfig,
                             PipelineTaskConnections)
 from lsst.pipe.base import connectionTypes as cT
 
-_LOG = logging.getLogger(__name__.partition(".")[2])
+_LOG = logging.getLogger(__name__)
 
 
 class RawToCalexpTaskConnections(PipelineTaskConnections,

--- a/python/lsst/ctrl/mpexec/examples/test1task.py
+++ b/python/lsst/ctrl/mpexec/examples/test1task.py
@@ -10,7 +10,7 @@ from lsst.pipe.base import (Struct, PipelineTask, PipelineTaskConfig,
                             PipelineTaskConnections)
 from lsst.pipe.base import connectionTypes as cT
 
-_LOG = logging.getLogger(__name__.partition(".")[2])
+_LOG = logging.getLogger(__name__)
 
 
 class Test1Connections(PipelineTaskConnections,

--- a/python/lsst/ctrl/mpexec/examples/test2task.py
+++ b/python/lsst/ctrl/mpexec/examples/test2task.py
@@ -10,7 +10,7 @@ from lsst.pipe.base import (Struct, PipelineTask, PipelineTaskConfig,
                             PipelineTaskConnections)
 from lsst.pipe.base import connectionTypes as cT
 
-_LOG = logging.getLogger(__name__.partition(".")[2])
+_LOG = logging.getLogger(__name__)
 
 
 class Test2Connections(PipelineTaskConnections,

--- a/python/lsst/ctrl/mpexec/mpGraphExecutor.py
+++ b/python/lsst/ctrl/mpexec/mpGraphExecutor.py
@@ -42,7 +42,7 @@ from .quantumGraphExecutor import QuantumGraphExecutor
 from lsst.base import disableImplicitThreading
 from lsst.daf.butler.cli.cliLog import CliLog
 
-_LOG = logging.getLogger(__name__.partition(".")[2])
+_LOG = logging.getLogger(__name__)
 
 
 # Possible states for the executing task:

--- a/python/lsst/ctrl/mpexec/preExecInit.py
+++ b/python/lsst/ctrl/mpexec/preExecInit.py
@@ -33,7 +33,7 @@ import itertools
 from lsst.base import Packages
 from lsst.pipe.base import PipelineDatasetTypes
 
-_LOG = logging.getLogger(__name__.partition(".")[2])
+_LOG = logging.getLogger(__name__)
 
 
 class PreExecInit:

--- a/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
+++ b/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
@@ -67,7 +67,7 @@ from lsst.daf.butler.core.logging import (
 #  Local non-exported definitions --
 # ----------------------------------
 
-_LOG = logging.getLogger(__name__.partition(".")[2])
+_LOG = logging.getLogger(__name__)
 
 
 class _LogCaptureFlag:

--- a/python/lsst/ctrl/mpexec/taskFactory.py
+++ b/python/lsst/ctrl/mpexec/taskFactory.py
@@ -29,7 +29,7 @@ import logging
 from lsst.pipe.base import TaskFactory as BaseTaskFactory
 from lsst.daf.butler import DatasetType
 
-_LOG = logging.getLogger(__name__.partition(".")[2])
+_LOG = logging.getLogger(__name__)
 
 
 class TaskFactory(BaseTaskFactory):


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
