### PR TITLE
DM-31976: (v23) Use register-dataset-types option from daf_butler now

### DIFF
--- a/python/lsst/ctrl/mpexec/cli/opt/optionGroups.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/optionGroups.py
@@ -120,7 +120,7 @@ class meta_info_options(OptionGroup):  # noqa: N801
             option_section(sectionText="Meta-information output options:"),
             ctrlMpExecOpts.skip_init_writes_option(),
             ctrlMpExecOpts.init_only_option(),
-            ctrlMpExecOpts.register_dataset_types_option(),
+            dafButlerOpts.register_dataset_types_option(),
             ctrlMpExecOpts.no_versions_option()]
 
 

--- a/python/lsst/ctrl/mpexec/cli/opt/options.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/options.py
@@ -192,12 +192,6 @@ qgraph_dot_option = MWOptionDecorator("--qgraph-dot",
                                       type=MWPath(writable=True, file_okay=True, dir_okay=False))
 
 
-register_dataset_types_option = MWOptionDecorator("--register-dataset-types",
-                                                  help=unwrap("""Register DatasetTypes that do not already
-                                                              exist in the Registry."""),
-                                                  is_flag=True)
-
-
 replace_run_option = MWOptionDecorator("--replace-run",
                                        help=unwrap("""Before creating a new RUN collection in an existing
                                                    CHAINED collection, remove the first child collection


### PR DESCRIPTION
It was moved there so it could be used by daf_butler.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
