### PR TITLE
DM-33278: Check for dataset type compatibility before failing

### DIFF
--- a/python/lsst/ctrl/mpexec/preExecInit.py
+++ b/python/lsst/ctrl/mpexec/preExecInit.py
@@ -150,9 +150,17 @@ class PreExecInit:
                         "passing `--register-dataset-types` option to `pipetask run`."
                     ) from None
                 if expected != datasetType:
-                    raise ValueError(
-                        f"DatasetType configuration does not match Registry: {datasetType} != {expected}"
-                    )
+                    if expected.is_compatible_with(datasetType):
+                        _LOG.info(
+                            "The dataset type configurations differ (%s != %s from registry) "
+                            "but the storage classes are compatible. Can continue.",
+                            datasetType,
+                            expected,
+                        )
+                    else:
+                        raise ValueError(
+                            f"DatasetType configuration does not match Registry: {datasetType} != {expected}"
+                        )
 
     def saveInitOutputs(self, graph):
         """Write any datasets produced by initializing tasks in a graph.


### PR DESCRIPTION
If the dataset types differ, it might be that the storage classes are different. If the storage classes are compatible with each other continue.

Requires lsst/daf_butler#632.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
