### PR TITLE
DM-31253: Implement mock pipeline execution

### DIFF
--- a/python/lsst/ctrl/mpexec/cli/opt/optionGroups.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/optionGroups.py
@@ -125,6 +125,7 @@ class execution_options(OptionGroup):  # noqa: N801
             ctrlMpExecOpts.timeout_option(),
             ctrlMpExecOpts.fail_fast_option(),
             ctrlMpExecOpts.graph_fixup_option(),
+            ctrlMpExecOpts.mock_option(),
         ]
 
 

--- a/python/lsst/ctrl/mpexec/cli/opt/options.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/options.py
@@ -423,7 +423,7 @@ save_execution_butler_option = MWOptionDecorator(
 mock_option = MWOptionDecorator(
     "--mock",
     help=unwrap("""Mock pipeline execution."""),
-    is_flag=True
+    is_flag=True,
 )
 
 clobber_execution_butler_option = MWOptionDecorator(

--- a/python/lsst/ctrl/mpexec/cli/opt/options.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/options.py
@@ -420,6 +420,12 @@ save_execution_butler_option = MWOptionDecorator(
     ),
 )
 
+mock_option = MWOptionDecorator(
+    "--mock",
+    help=unwrap("""Mock pipeline execution."""),
+    is_flag=True
+)
+
 clobber_execution_butler_option = MWOptionDecorator(
     "--clobber-execution-butler",
     help=unwrap(

--- a/python/lsst/ctrl/mpexec/cli/script/run.py
+++ b/python/lsst/ctrl/mpexec/cli/script/run.py
@@ -53,6 +53,7 @@ def run(
     fail_fast,
     clobber_outputs,
     mock,
+    mock_configs,
     **kwargs,
 ):
     """Implements the command line interface `pipetask run` subcommand, should
@@ -142,6 +143,8 @@ def run(
         given.
     mock : `bool`, optional
         If `True` then run mock pipeline instead of real one.
+    mock_configs : `list` [ `PipelineAction` ]
+        A list of config overrides for mock tasks.
     kwargs : `dict` [`str`, `str`]
         Ignored; click commands may accept options for more than one script
         function and pass all the option kwargs to each of the script functions
@@ -172,6 +175,7 @@ def run(
         fail_fast=fail_fast,
         clobber_outputs=clobber_outputs,
         mock=mock,
+        mock_configs=mock_configs,
     )
 
     f = CmdLineFwk()

--- a/python/lsst/ctrl/mpexec/cli/script/run.py
+++ b/python/lsst/ctrl/mpexec/cli/script/run.py
@@ -52,6 +52,7 @@ def run(
     debug,
     fail_fast,
     clobber_outputs,
+    mock,
     **kwargs,
 ):
     """Implements the command line interface `pipetask run` subcommand, should
@@ -139,6 +140,8 @@ def run(
         Remove outputs from previous execution of the same quantum before new
         execution.  Only applies to failed quanta if skip_existing is also
         given.
+    mock : `bool`, optional
+        If `True` then run mock pipeline instead of real one.
     kwargs : `dict` [`str`, `str`]
         Ignored; click commands may accept options for more than one script
         function and pass all the option kwargs to each of the script functions
@@ -168,6 +171,7 @@ def run(
         enableLsstDebug=debug,
         fail_fast=fail_fast,
         clobber_outputs=clobber_outputs,
+        mock=mock,
     )
 
     f = CmdLineFwk()

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -702,7 +702,7 @@ class CmdLineFwk:
                 _LOG.warn("No 'debug' module found.")
 
         # Save all InitOutputs, configs, etc.
-        preExecInit = PreExecInit(butler, taskFactory, extendRun=args.extend_run)
+        preExecInit = PreExecInit(butler, taskFactory, extendRun=args.extend_run, mock=args.mock)
         preExecInit.initialize(
             graph,
             saveInitOutputs=not args.skip_init_writes,
@@ -718,6 +718,7 @@ class CmdLineFwk:
                 clobberOutputs=args.clobber_outputs,
                 enableLsstDebug=args.enableLsstDebug,
                 exitOnKnownError=args.fail_fast,
+                mock=args.mock,
             )
             timeout = self.MP_TIMEOUT if args.timeout is None else args.timeout
             executor = MPGraphExecutor(

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -719,6 +719,7 @@ class CmdLineFwk:
                 enableLsstDebug=args.enableLsstDebug,
                 exitOnKnownError=args.fail_fast,
                 mock=args.mock,
+                mock_configs=args.mock_configs,
             )
             timeout = self.MP_TIMEOUT if args.timeout is None else args.timeout
             executor = MPGraphExecutor(

--- a/python/lsst/ctrl/mpexec/dataid_match.py
+++ b/python/lsst/ctrl/mpexec/dataid_match.py
@@ -1,0 +1,170 @@
+# This file is part of ctrl_mpexec.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+__all__ = ["DataIdMatch"]
+
+import operator
+from typing import Any, List, Optional, Tuple
+
+import astropy.time
+from lsst.daf.butler import DataId
+from lsst.daf.butler.registry.queries.expressions import Node, ParserYacc, TreeVisitor
+
+
+class _DataIdMatchTreeVisitor(TreeVisitor):
+    """Expression tree visitor which evaluates expression using values from
+    DataId.
+    """
+
+    def __init__(self, dataId: DataId):
+        self.dataId = dataId
+
+    def visitNumericLiteral(self, value: str, node: Node) -> Any:
+        # docstring is inherited from base class
+        try:
+            return int(value)
+        except ValueError:
+            return float(value)
+
+    def visitStringLiteral(self, value: str, node: Node) -> Any:
+        # docstring is inherited from base class
+        return value
+
+    def visitTimeLiteral(self, value: astropy.time.Time, node: Node) -> Any:
+        # docstring is inherited from base class
+        return value
+
+    def visitRangeLiteral(self, start: int, stop: int, stride: Optional[int], node: Node) -> Any:
+        # docstring is inherited from base class
+        if stride is None:
+            return range(start, stop + 1)
+        else:
+            return range(start, stop + 1, stride)
+
+    def visitIdentifier(self, name: str, node: Node) -> Any:
+        # docstring is inherited from base class
+        return self.dataId[name]
+
+    def visitUnaryOp(self, operator_name: str, operand: Any, node: Node) -> Any:
+        # docstring is inherited from base class
+        operators = {
+            "NOT": operator.not_,
+            "+": operator.pos,
+            "-": operator.neg,
+        }
+        return operators[operator_name](operand)
+
+    def visitBinaryOp(self, operator_name: str, lhs: Any, rhs: Any, node: Node) -> Any:
+        # docstring is inherited from base class
+        operators = {
+            "OR": operator.or_,
+            "AND": operator.and_,
+            "+": operator.add,
+            "-": operator.sub,
+            "*": operator.mul,
+            "/": operator.truediv,
+            "%": operator.mod,
+            "=": operator.eq,
+            "!=": operator.ne,
+            "<": operator.lt,
+            ">": operator.gt,
+            "<=": operator.le,
+            ">=": operator.ge,
+        }
+        return operators[operator_name](lhs, rhs)
+
+    def visitIsIn(self, lhs: Any, values: List[Any], not_in: bool, node: Node) -> Any:
+        # docstring is inherited from base class
+        is_in = True
+        for value in values:
+            if not isinstance(value, range):
+                value = [value]
+            if lhs in value:
+                break
+        else:
+            is_in = False
+        if not_in:
+            is_in = not is_in
+        return is_in
+
+    def visitParens(self, expression: Any, node: Node) -> Any:
+        # docstring is inherited from base class
+        return expression
+
+    def visitTupleNode(self, items: Tuple[Any, ...], node: Node) -> Any:
+        # docstring is inherited from base class
+        raise NotImplementedError()
+
+    def visitFunctionCall(self, name: str, args: List[Any], node: Node) -> Any:
+        # docstring is inherited from base class
+        raise NotImplementedError()
+
+    def visitPointNode(self, ra: Any, dec: Any, node: Node) -> Any:
+        # docstring is inherited from base class
+        raise NotImplementedError()
+
+
+class DataIdMatch:
+    """Class that can match DataId against the user-defined string expression.
+
+    Parameters
+    ----------
+    expression : `str`
+        User-defined expression, supports syntax defined by daf_butler
+        expression parser. Maps identifiers in the expression to the values of
+        DataId.
+    """
+
+    def __init__(self, expression: str):
+        parser = ParserYacc()
+        self.expression = expression
+        self.tree = parser.parse(expression)
+
+    def match(self, dataId: DataId) -> bool:
+        """Matches DataId contents against the expression.
+
+        Parameters
+        ----------
+        dataId : `DataId`
+            DataId that is matched against an expression.
+
+        Returns
+        -------
+        match : `bool`
+            Result of expression evaluation.
+
+        Raises
+        ------
+        KeyError
+            Raised when identifier in expression is not defined for given
+            `DataId`.
+        TypeError
+            Raised when expression evaluates to a non-boolean type or when
+            operation in expression cannot be performed on operand types.
+        NotImplementedError
+            Raised when expression includes valid but unsupported syntax, e.g.
+            function call.
+        """
+        visitor = _DataIdMatchTreeVisitor(dataId)
+        result = self.tree.visit(visitor)
+        if not isinstance(result, bool):
+            raise TypeError(f"Expression '{self.expression}' returned non-boolean object {type(result)}")
+        return result

--- a/python/lsst/ctrl/mpexec/mock_task.py
+++ b/python/lsst/ctrl/mpexec/mock_task.py
@@ -1,0 +1,172 @@
+# This file is part of ctrl_mpexec.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+from typing import Any, List, Union
+
+from lsst.daf.butler import Butler, DatasetRef, Quantum
+from lsst.pipe.base import (
+    ButlerQuantumContext,
+    DeferredDatasetRef,
+    InputQuantizedConnection,
+    OutputQuantizedConnection,
+    PipelineTask,
+    PipelineTaskConfig,
+)
+from lsst.utils.introspection import get_full_type_name
+
+
+_LOG = logging.getLogger(__name__)
+
+
+class MockButlerQuantumContext(ButlerQuantumContext):
+    """Implementation of ButlerQuantumContext to use with a mock task.
+
+    Parameters
+    ----------
+    butler : `~lsst.daf.butler.Butler`
+        Data butler instance.
+    quantum : `~lsst.daf.butler.Quantum`
+        Execution quantum.
+
+    Notes
+    -----
+    This implementation overrides get method to try to retrieve dataset from a
+    mock dataset type if it exists. Get method always returns a dictionary.
+    Put method stores the data with a mock dataset type, but also registers
+    DatasetRef with registry using original dataset type.
+    """
+
+    def __init__(self, butler: Butler, quantum: Quantum):
+        super().__init__(butler, quantum)
+        self.butler = butler
+
+    @classmethod
+    def mockDatasetTypeName(cls, datasetTypeName: str) -> str:
+        """Make mock dataset type name from actual dataset type name."""
+        return "_mock_" + datasetTypeName
+
+    def _get(self, ref: DatasetRef) -> Any:
+        # docstring is inherited from the base class
+        if isinstance(ref, DeferredDatasetRef):
+            ref = ref.datasetRef
+        datasetType = ref.datasetType
+
+        typeName, component = datasetType.nameAndComponent()
+        if component is not None:
+            mockDatasetTypeName = self.mockDatasetTypeName(typeName)
+        else:
+            mockDatasetTypeName = self.mockDatasetTypeName(datasetType.name)
+
+        try:
+            mockDatasetType = self.butler.registry.getDatasetType(mockDatasetTypeName)
+            ref = DatasetRef(mockDatasetType, ref.dataId)
+            data = self.butler.get(ref)
+        except KeyError:
+            data = super()._get(ref)
+
+        if not isinstance(data, dict):
+            data = {
+                "ref": {
+                    "dataId": {key.name: ref.dataId[key] for key in ref.dataId.keys()},
+                    "datasetType": ref.datasetType.name,
+                },
+                "type": get_full_type_name(type(data)),
+            }
+        if component is not None:
+            data.update(component=component)
+        return data
+
+    def _put(self, value: Any, ref: DatasetRef):
+        # docstring is inherited from the base class
+
+        mockDatasetType = self.registry.getDatasetType(self.mockDatasetTypeName(ref.datasetType.name))
+        mockRef = DatasetRef(mockDatasetType, ref.dataId)
+        value.setdefault("ref", {}).update(datasetType=mockDatasetType.name)
+        self.butler.put(value, mockRef)
+
+        # also "store" non-mock refs
+        self.registry._importDatasets([ref])
+
+    def _checkMembership(self, ref: Union[List[DatasetRef], DatasetRef], inout: set):
+        # docstring is inherited from the base class
+        return
+
+
+class MockPipelineTask(PipelineTask):
+    """Implementation of PipelineTask used for running a mock pipeline.
+
+    Notes
+    -----
+    This class overrides `runQuantum` to read all input datasetRefs and to
+    store simple dictionary as output data. Output dictionary contains some
+    provenance data about inputs, the task that produced it, and corresponding
+    quantum. This class depends on `MockButlerQuantumContext` which knows how
+    to store the output dictionary data with special dataset types.
+    """
+
+    ConfigClass = PipelineTaskConfig
+
+    def runQuantum(
+        self,
+        butlerQC: ButlerQuantumContext,
+        inputRefs: InputQuantizedConnection,
+        outputRefs: OutputQuantizedConnection,
+    ):
+        # docstring is inherited from the base class
+        quantum = butlerQC.quantum
+
+        _LOG.info("Mocking execution of task '%s' on quantum %s", self.getName(), quantum.dataId)
+
+        # read all inputs
+        inputs = butlerQC.get(inputRefs)
+
+        _LOG.info("Read input data for task '%s' on quantum %s", self.getName(), quantum.dataId)
+
+        # To avoid very deep provenance we trim inputs to a single level
+        for name, data in inputs.items():
+            if isinstance(data, dict):
+                data = [data]
+            if isinstance(data, list):
+                for item in data:
+                    qdata = item.get("quantum", {})
+                    qdata.pop("inputs", None)
+
+        # store mock outputs
+        for name, refs in outputRefs:
+            if not isinstance(refs, list):
+                refs = [refs]
+            for ref in refs:
+                data = {
+                    "ref": {
+                        "dataId": {key.name: ref.dataId[key] for key in ref.dataId.keys()},
+                        "datasetType": ref.datasetType.name,
+                    },
+                    "quantum": {
+                        "task": self.getName(),
+                        "dataId": {key.name: quantum.dataId[key] for key in quantum.dataId.keys()},
+                        "inputs": inputs,
+                    },
+                    "outputName": name,
+                }
+                butlerQC.put(data, ref)
+
+        _LOG.info("Finished mocking task '%s' on quantum %s", self.getName(), quantum.dataId)

--- a/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
+++ b/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
@@ -55,6 +55,7 @@ from lsst.utils.timer import logInfo
 # -----------------------------
 #  Imports for other modules --
 # -----------------------------
+from .mock_task import MockButlerQuantumContext, MockPipelineTask
 from .quantumGraphExecutor import QuantumExecutor
 
 # ----------------------------------
@@ -93,6 +94,8 @@ class SingleQuantumExecutor(QuantumExecutor):
         known exceptions, after printing a traceback, instead of letting the
         exception propagate up to calling.  This is always the behavior for
         InvalidQuantumError.
+    mock : `bool`, optional
+        If `True` then mock task execution.
     """
 
     stream_json_logs = True
@@ -107,12 +110,14 @@ class SingleQuantumExecutor(QuantumExecutor):
         clobberOutputs=False,
         enableLsstDebug=False,
         exitOnKnownError=False,
+        mock=False,
     ):
         self.taskFactory = taskFactory
         self.skipExistingIn = skipExistingIn
         self.enableLsstDebug = enableLsstDebug
         self.clobberOutputs = clobberOutputs
         self.exitOnKnownError = exitOnKnownError
+        self.mock = mock
         self.log_handler = None
 
     def execute(self, taskDef, quantum, butler):
@@ -176,7 +181,12 @@ class SingleQuantumExecutor(QuantumExecutor):
             task = self.makeTask(taskClass, label, config, butler)
             logInfo(None, "start", metadata=quantumMetadata)
             try:
-                self.runQuantum(task, quantum, taskDef, butler)
+                if self.mock:
+                    # Use mock task instance to execute method.
+                    runTask = MockPipelineTask(name=taskDef.label)
+                else:
+                    runTask = task
+                self.runQuantum(runTask, quantum, taskDef, butler)
             except Exception as e:
                 _LOG.error(
                     "Execution of task '%s' on quantum %s failed. Exception %s: %s",
@@ -434,9 +444,37 @@ class SingleQuantumExecutor(QuantumExecutor):
                 # We need to ask datastore if the dataset actually exists
                 # because the Registry of a local "execution butler" cannot
                 # know this (because we prepopulate it with all of the datasets
-                # that might be created).
-                if butler.datastore.exists(resolvedRef):
+                # that might be created). In case of mock execution we check
+                # that mock dataset exists instead.
+                if self.mock:
+                    try:
+                        typeName, component = ref.datasetType.nameAndComponent()
+                        if component is not None:
+                            mockDatasetTypeName = MockButlerQuantumContext.mockDatasetTypeName(typeName)
+                        else:
+                            mockDatasetTypeName = MockButlerQuantumContext.mockDatasetTypeName(
+                                ref.datasetType.name
+                            )
+
+                        mockDatasetType = butler.registry.getDatasetType(mockDatasetTypeName)
+                    except KeyError:
+                        # means that mock dataset type is not there and this
+                        # should be a pre-existing dataset
+                        _LOG.debug("No mock dataset type for %s", ref)
+                        if butler.datastore.exists(resolvedRef):
+                            newRefsForDatasetType.append(resolvedRef)
+                    else:
+                        mockRef = DatasetRef(mockDatasetType, ref.dataId)
+                        resolvedMockRef = butler.registry.findDataset(
+                            mockRef.datasetType, mockRef.dataId, collections=butler.collections
+                        )
+                        _LOG.debug("mockRef=%s resolvedMockRef=%s", mockRef, resolvedMockRef)
+                        if resolvedMockRef is not None and butler.datastore.exists(resolvedMockRef):
+                            _LOG.debug("resolvedMockRef dataset exists")
+                            newRefsForDatasetType.append(resolvedRef)
+                elif butler.datastore.exists(resolvedRef):
                     newRefsForDatasetType.append(resolvedRef)
+
             if len(newRefsForDatasetType) != len(refsForDatasetType):
                 anyChanges = True
         # If we removed any input datasets, let the task check if it has enough
@@ -474,7 +512,10 @@ class SingleQuantumExecutor(QuantumExecutor):
             Data butler.
         """
         # Create a butler that operates in the context of a quantum
-        butlerQC = ButlerQuantumContext(butler, quantum)
+        if self.mock:
+            butlerQC = MockButlerQuantumContext(butler, quantum)
+        else:
+            butlerQC = ButlerQuantumContext(butler, quantum)
 
         # Get the input and output references for the task
         inputRefs, outputRefs = taskDef.connections.buildDatasetRefs(quantum)

--- a/tests/test_dataid_match.py
+++ b/tests/test_dataid_match.py
@@ -1,0 +1,151 @@
+# This file is part of ctrl_mpexec.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+
+from lsst.ctrl.mpexec.dataid_match import DataIdMatch
+
+
+class DataIdMatchTestCase(unittest.TestCase):
+    """A test case for DataidMatch class"""
+
+    dataIds = (
+        {"instrument": "INSTR", "detector": 1, "number": 4},
+        {"instrument": "INSTR", "detector": 2, "number": 3},
+        {"instrument": "LSST", "detector": 3, "number": 2},
+        {"instrument": "LSST", "detector": 4, "number": 1},
+    )
+
+    def test_strings(self):
+        """Tests for string comparisons method"""
+
+        tests = (
+            ("instrument = 'INSTR'", [True, True, False, False]),
+            ("instrument = 'LSST'", [False, False, True, True]),
+            ("instrument < 'LSST'", [True, True, False, False]),
+            ("instrument IN ('LSST', 'INSTR')", [True, True, True, True]),
+        )
+
+        for expr, result in tests:
+            dataIdMatch = DataIdMatch(expr)
+            self.assertEqual([dataIdMatch.match(dataId) for dataId in self.dataIds], result)
+
+    def test_comparisons(self):
+        """Test all supported comparison operators"""
+
+        tests = (
+            ("detector = 1", [True, False, False, False]),
+            ("detector != 1", [False, True, True, True]),
+            ("detector > 2", [False, False, True, True]),
+            ("2 <= detector", [False, True, True, True]),
+            ("2 > detector", [True, False, False, False]),
+            ("2 >= detector", [True, True, False, False]),
+        )
+
+        for expr, result in tests:
+            dataIdMatch = DataIdMatch(expr)
+            self.assertEqual([dataIdMatch.match(dataId) for dataId in self.dataIds], result)
+
+    def test_arith(self):
+        """Test all supported arithmetical operators"""
+
+        tests = (
+            ("detector + number = 5", [True, True, True, True]),
+            ("detector - number = 1", [False, False, True, False]),
+            ("detector * number = 6", [False, True, True, False]),
+            ("detector / number = 1.5", [False, False, True, False]),
+            ("detector % number = 1", [True, False, True, False]),
+            ("+detector = 1", [True, False, False, False]),
+            ("-detector = -4", [False, False, False, True]),
+        )
+
+        for expr, result in tests:
+            dataIdMatch = DataIdMatch(expr)
+            self.assertEqual([dataIdMatch.match(dataId) for dataId in self.dataIds], result)
+
+    def test_logical(self):
+        """Test all supported logical operators"""
+
+        tests = (
+            ("detector = 1 OR instrument = 'LSST'", [True, False, True, True]),
+            ("detector = 1 AND instrument = 'INSTR'", [True, False, False, False]),
+            ("NOT detector = 1", [False, True, True, True]),
+        )
+
+        for expr, result in tests:
+            dataIdMatch = DataIdMatch(expr)
+            self.assertEqual([dataIdMatch.match(dataId) for dataId in self.dataIds], result)
+
+    def test_parens(self):
+        """Test parentheses"""
+
+        tests = (("(detector = 1 OR number = 1) AND instrument = 'LSST'", [False, False, False, True]),)
+
+        for expr, result in tests:
+            dataIdMatch = DataIdMatch(expr)
+            self.assertEqual([dataIdMatch.match(dataId) for dataId in self.dataIds], result)
+
+    def test_in(self):
+        """Test IN expression"""
+
+        tests = (
+            ("detector in (1, 3, 2)", [True, True, True, False]),
+            ("detector not in (1, 3, 2)", [False, False, False, True]),
+            ("detector in (1..4:2)", [True, False, True, False]),
+            ("detector in (1..4:2, 4)", [True, False, True, True]),
+        )
+
+        for expr, result in tests:
+            dataIdMatch = DataIdMatch(expr)
+            self.assertEqual([dataIdMatch.match(dataId) for dataId in self.dataIds], result)
+
+    def test_errors(self):
+        """Test for errors in expressions"""
+
+        dataId = {"instrument": "INSTR", "detector": 1}
+
+        # Unknown identifier
+        expr = "INSTRUMENT = 'INSTR'"
+        dataIdMatch = DataIdMatch(expr)
+        with self.assertRaisesRegex(KeyError, "INSTRUMENT"):
+            dataIdMatch.match(dataId)
+
+        # non-boolean expression
+        expr = "instrument"
+        dataIdMatch = DataIdMatch(expr)
+        with self.assertRaisesRegex(TypeError, "Expression 'instrument' returned non-boolean object"):
+            dataIdMatch.match(dataId)
+
+        # operations on unsupported combination of types
+        expr = "instrument - detector = 0"
+        dataIdMatch = DataIdMatch(expr)
+        with self.assertRaisesRegex(TypeError, "unsupported operand type"):
+            dataIdMatch.match(dataId)
+
+        # function calls are not implemented
+        expr = "POINT(2, 1) != POINT(1, 2)"
+        dataIdMatch = DataIdMatch(expr)
+        with self.assertRaises(NotImplementedError):
+            dataIdMatch.match(dataId)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`pipelinetask` adds a --mock option, with that option enabled the framework
skips calling task runQuantum method and instead executes a special method
that writes provenance data as dictionaries. With this it is possible to run
the whole ci_hsc_gen3 pipeline in a mock mode which executes much faster.

Options --config and --config-file can specify task label as "{label}-mock",
this applies config overrides to mock tasks matching corresponding label. Mock
task has two config fields - `failCondition` which specifies condition for
generating an exception, and `failException` which specifies exception class
name.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
