### PR TITLE
Continue execution after task failure (DM-33339)

### DIFF
--- a/doc/changes/DM-33339.misc.md
+++ b/doc/changes/DM-33339.misc.md
@@ -1,0 +1,1 @@
+Allow `pipetask run` execution to continue in single-process mode after failure of one or more tasks. Previously execution stopped on an exception from any task.

--- a/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
+++ b/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
@@ -178,7 +178,7 @@ class SingleQuantumExecutor(QuantumExecutor):
             try:
                 self.runQuantum(task, quantum, taskDef, butler)
             except Exception as e:
-                _LOG.exception(
+                _LOG.error(
                     "Execution of task '%s' on quantum %s failed. Exception %s: %s",
                     taskDef.label,
                     quantum.dataId,

--- a/tests/test_cmdLineFwk.py
+++ b/tests/test_cmdLineFwk.py
@@ -39,6 +39,7 @@ import click
 import lsst.pex.config as pexConfig
 import lsst.pipe.base.connectionTypes as cT
 import lsst.utils.tests
+from lsst.ctrl.mpexec import CmdLineFwk, MPGraphExecutorError
 from lsst.ctrl.mpexec.cli.opt import run_options
 from lsst.ctrl.mpexec.cli.utils import (
     _ACTION_ADD_INSTRUMENT,
@@ -47,7 +48,6 @@ from lsst.ctrl.mpexec.cli.utils import (
     _ACTION_CONFIG_FILE,
     PipetaskCommand,
 )
-from lsst.ctrl.mpexec.cmdLineFwk import CmdLineFwk
 from lsst.daf.butler import Config, DataCoordinate, DatasetRef, DimensionUniverse, Quantum, Registry
 from lsst.daf.butler.core.datasets.type import DatasetType
 from lsst.daf.butler.registry import RegistryConfig
@@ -562,7 +562,7 @@ class CmdLineFwkTestCaseWithButler(unittest.TestCase):
         self.assertEqual(len(qgraph), self.nQuanta)
 
         # run first three quanta
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(MPGraphExecutorError):
             fwk.runPipeline(qgraph, taskFactory, args)
         self.assertEqual(taskFactory.countExec, 3)
 
@@ -584,8 +584,7 @@ class CmdLineFwkTestCaseWithButler(unittest.TestCase):
         args.skip_existing_in = (args.output,)
         args.extend_run = True
         args.no_versions = True
-        excRe = "Registry inconsistency while checking for existing outputs.*"
-        with self.assertRaisesRegex(RuntimeError, excRe):
+        with self.assertRaises(MPGraphExecutorError):
             fwk.runPipeline(qgraph, taskFactory, args)
 
     def testSimpleQGraphClobberOutputs(self):
@@ -605,7 +604,7 @@ class CmdLineFwkTestCaseWithButler(unittest.TestCase):
         self.assertEqual(len(qgraph), self.nQuanta)
 
         # run first three quanta
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(MPGraphExecutorError):
             fwk.runPipeline(qgraph, taskFactory, args)
         self.assertEqual(taskFactory.countExec, 3)
 


### PR DESCRIPTION
In a single-process mode the MPGraphExecutor will try to execute remaining
tasks after one of the tasks fails (skipping the tasks that depend on
outputs of failed tasks) instead of exiting on an exception. This needed
some changes in exception handling, instead of passing an original
exeption raised by a task, it now raises MPGraphExecutorError, this is
consistent with multi-process case. Task timeouts are not handled in
single-process case.

## Checklist

- [X] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
