### PR TITLE
Continue execution after task failure (DM-33339)

### DIFF
--- a/doc/changes/DM-33339.misc.md
+++ b/doc/changes/DM-33339.misc.md
@@ -1,0 +1,1 @@
+Allow `pipetask run` execution to continue in single-process mode after failure of one or more tasks. Previously execution stopped on an exception from any task.

--- a/python/lsst/ctrl/mpexec/mpGraphExecutor.py
+++ b/python/lsst/ctrl/mpexec/mpGraphExecutor.py
@@ -158,8 +158,8 @@ class _JobList:
 
     Parameters
     ----------
-    iterable : iterable of `~lsst.pipe.base.QuantumIterData`
-        Sequence if Quanta to execute. This has to be ordered according to
+    iterable : iterable of `~lsst.pipe.base.QuantumNode`
+        Sequence of Quanta to execute. This has to be ordered according to
         task dependencies.
     """
     def __init__(self, iterable):
@@ -343,22 +343,57 @@ class MPGraphExecutor(QuantumGraphExecutor):
         butler : `lsst.daf.butler.Butler`
             Data butler instance
         """
-        # Note that in non-MP case any failed task will generate an exception
-        # and kill the whole thing. In general we cannot guarantee exception
-        # safety so easiest and safest thing is to let it die.
-        count, totalCount = 0, len(graph)
+        successCount, totalCount = 0, len(graph)
+        failedNodes = set()
         for qnode in graph:
+
+            # Any failed inputs mean that the quantum has to be skipped.
+            inputNodes = graph.determineInputsToQuantumNode(qnode)
+            if inputNodes & failedNodes:
+                _LOG.error(
+                    "Upstream job failed for task <%s dataId=%s>, skipping this task.",
+                    qnode.taskDef,
+                    qnode.quantum.dataId,
+                )
+                failedNodes.add(qnode)
+                continue
+
             _LOG.debug("Executing %s", qnode)
             try:
                 self.quantumExecutor.execute(qnode.taskDef, qnode.quantum, butler)
+                successCount += 1
+            except Exception as exc:
+                failedNodes.add(qnode)
+                if self.failFast:
+                    raise MPGraphExecutorError(
+                        f"Task <{qnode.taskDef} dataId={qnode.quantum.dataId}> failed."
+                    ) from exc
+                else:
+                    # Note that there could be exception safety issues, which
+                    # we presently ignore.
+                    _LOG.error(
+                        "Task <%s dataId=%s> failed; processing will continue for remaining tasks.",
+                        qnode.taskDef,
+                        qnode.quantum.dataId,
+                        exc_info=exc,
+                    )
             finally:
                 # sqlalchemy has some objects that can last until a garbage
                 # collection cycle is run, which can happen at unpredictable
                 # times, run a collection loop here explicitly.
                 gc.collect()
-            count += 1
-            _LOG.info("Executed %d quanta, %d remain out of total %d quanta.",
-                      count, totalCount - count, totalCount)
+
+            _LOG.info(
+                "Executed %d quanta successfully, %d failed and %d remain out of total %d quanta.",
+                successCount,
+                len(failedNodes),
+                totalCount - successCount - len(failedNodes),
+                totalCount,
+            )
+
+        # Raise an exception if there were any failures.
+        if failedNodes:
+            raise MPGraphExecutorError("One or more tasks failed during execution.")
 
     def _executeQuantaMP(self, graph, butler):
         """Execute all Quanta in separate processes.

--- a/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
+++ b/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
@@ -173,8 +173,13 @@ class SingleQuantumExecutor(QuantumExecutor):
             try:
                 self.runQuantum(task, quantum, taskDef, butler)
             except Exception as e:
-                _LOG.exception("Execution of task '%s' on quantum %s failed. Exception %s: %s",
-                               taskDef.label, quantum.dataId, e.__class__.__name__, str(e))
+                _LOG.error(
+                    "Execution of task '%s' on quantum %s failed. Exception %s: %s",
+                    taskDef.label,
+                    quantum.dataId,
+                    e.__class__.__name__,
+                    str(e),
+                )
                 raise
             logInfo(None, "end", metadata=quantumMetadata)
             fullMetadata = task.getFullMetadata()

--- a/tests/test_cmdLineFwk.py
+++ b/tests/test_cmdLineFwk.py
@@ -36,7 +36,7 @@ import tempfile
 from typing import NamedTuple
 import unittest
 
-from lsst.ctrl.mpexec.cmdLineFwk import CmdLineFwk
+from lsst.ctrl.mpexec import CmdLineFwk, MPGraphExecutorError
 from lsst.ctrl.mpexec.cli.opt import run_options
 from lsst.ctrl.mpexec.cli.utils import (
     _ACTION_ADD_TASK,
@@ -519,7 +519,7 @@ class CmdLineFwkTestCaseWithButler(unittest.TestCase):
         self.assertEqual(len(qgraph), self.nQuanta)
 
         # run first three quanta
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(MPGraphExecutorError):
             fwk.runPipeline(qgraph, taskFactory, args)
         self.assertEqual(taskFactory.countExec, 3)
 
@@ -539,8 +539,7 @@ class CmdLineFwkTestCaseWithButler(unittest.TestCase):
         args.skip_existing_in = (args.output, )
         args.extend_run = True
         args.no_versions = True
-        excRe = "Registry inconsistency while checking for existing outputs.*"
-        with self.assertRaisesRegex(RuntimeError, excRe):
+        with self.assertRaises(MPGraphExecutorError):
             fwk.runPipeline(qgraph, taskFactory, args)
 
     def testSimpleQGraphClobberOutputs(self):
@@ -560,7 +559,7 @@ class CmdLineFwkTestCaseWithButler(unittest.TestCase):
         self.assertEqual(len(qgraph), self.nQuanta)
 
         # run first three quanta
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(MPGraphExecutorError):
             fwk.runPipeline(qgraph, taskFactory, args)
         self.assertEqual(taskFactory.countExec, 3)
 


### PR DESCRIPTION
In a single-process mode the MPGraphExecutor will try to execute remaining
tasks after one of the tasks fails (skipping the tasks that depend on
outputs of failed tasks) instead of exiting on an exception. This needed
some changes in exception handling, instead of passing an original
exception raised by a task, it now raises MPGraphExecutorError, this is
consistent with multi-process case. Task timeouts are not handled in
single-process case.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
