### PR TITLE
DM-33481: Add support for jobreport

### DIFF
--- a/doc/changes/DM-33481.feature.md
+++ b/doc/changes/DM-33481.feature.md
@@ -1,0 +1,1 @@
+Add `--summary` option to `pipetask run` command, it produces JSON report for execution status of the whole process and individual quanta.

--- a/python/lsst/ctrl/mpexec/__init__.py
+++ b/python/lsst/ctrl/mpexec/__init__.py
@@ -25,6 +25,7 @@ from .executionGraphFixup import *
 from .mpGraphExecutor import *
 from .preExecInit import *
 from .quantumGraphExecutor import *
+from .reports import *
 from .simple_pipeline_executor import *
 from .singleQuantumExecutor import *
 from .taskFactory import *

--- a/python/lsst/ctrl/mpexec/cli/opt/optionGroups.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/optionGroups.py
@@ -126,6 +126,7 @@ class execution_options(OptionGroup):  # noqa: N801
             ctrlMpExecOpts.fail_fast_option(),
             ctrlMpExecOpts.graph_fixup_option(),
             ctrlMpExecOpts.mock_option(),
+            ctrlMpExecOpts.summary_option(),
         ]
 
 

--- a/python/lsst/ctrl/mpexec/cli/opt/options.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/options.py
@@ -446,3 +446,12 @@ dataset_query_constraint = MWOptionDecorator(
     ),
     default="all",
 )
+
+summary_option = MWOptionDecorator(
+    "--summary",
+    help=(
+        "Location for storing job summary (JSON file). Note that the"
+        " structure of this file may not be stable."
+    ),
+    type=MWPath(dir_okay=False, file_okay=True, writable=True),
+)

--- a/python/lsst/ctrl/mpexec/cli/script/run.py
+++ b/python/lsst/ctrl/mpexec/cli/script/run.py
@@ -52,6 +52,7 @@ def run(
     debug,
     fail_fast,
     clobber_outputs,
+    summary,
     mock,
     mock_configs,
     **kwargs,
@@ -141,6 +142,8 @@ def run(
         Remove outputs from previous execution of the same quantum before new
         execution.  Only applies to failed quanta if skip_existing is also
         given.
+    summary : `str`
+        File path to store job report in JSON format.
     mock : `bool`, optional
         If `True` then run mock pipeline instead of real one.
     mock_configs : `list` [ `PipelineAction` ]
@@ -174,6 +177,7 @@ def run(
         enableLsstDebug=debug,
         fail_fast=fail_fast,
         clobber_outputs=clobber_outputs,
+        summary=summary,
         mock=mock,
         mock_configs=mock_configs,
     )

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -730,8 +730,16 @@ class CmdLineFwk:
                 failFast=args.fail_fast,
                 executionGraphFixup=graphFixup,
             )
-            with util.profile(args.profile, _LOG):
-                executor.execute(graph, butler)
+            try:
+                with util.profile(args.profile, _LOG):
+                    executor.execute(graph, butler)
+            finally:
+                if args.summary:
+                    report = executor.getReport()
+                    if report:
+                        with open(args.summary, "w") as out:
+                            # Do not save fields that are not set.
+                            out.write(report.json(exclude_none=True, indent=2))
 
     def showInfo(self, args, pipeline, graph=None):
         """Display useful info about pipeline and environment.

--- a/python/lsst/ctrl/mpexec/quantumGraphExecutor.py
+++ b/python/lsst/ctrl/mpexec/quantumGraphExecutor.py
@@ -21,14 +21,10 @@
 
 __all__ = ["QuantumExecutor", "QuantumGraphExecutor"]
 
-# -------------------------------
-#  Imports of standard modules --
-# -------------------------------
 from abc import ABC, abstractmethod
+from typing import Optional
 
-# -----------------------------
-#  Imports for other modules --
-# -----------------------------
+from .reports import QuantumReport, Report
 
 
 class QuantumExecutor(ABC):
@@ -68,7 +64,24 @@ class QuantumExecutor(ABC):
         Any exception raised by the task or code that wraps task execution is
         propagated to the caller of this method.
         """
-        raise NotImplementedError
+        raise NotImplementedError()
+
+    def getReport(self) -> Optional[QuantumReport]:
+        """Return execution report from last call to `execute`.
+
+        Returns
+        -------
+        report : `~lsst.ctrl.mpexec.QuantumReport`
+            Structure describing the status of the execution of a quantum.
+            `None` is returned if implementation does not support this
+            feature.
+
+        Raises
+        ------
+        RuntimeError
+            Raised if this method is called before `execute`.
+        """
+        return None
 
 
 class QuantumGraphExecutor(ABC):
@@ -94,4 +107,21 @@ class QuantumGraphExecutor(ABC):
         butler : `~lsst.daf.butler.Butler`
             Data butler instance
         """
-        raise NotImplementedError
+        raise NotImplementedError()
+
+    def getReport(self) -> Optional[Report]:
+        """Return execution report from last call to `execute`.
+
+        Returns
+        -------
+        report : `~lsst.ctrl.mpexec.Report`, optional
+            Structure describing the status of the execution of a quantum
+            graph. `None` is returned if implementation does not support
+            this feature.
+
+        Raises
+        ------
+        RuntimeError
+            Raised if this method is called before `execute`.
+        """
+        return None

--- a/python/lsst/ctrl/mpexec/reports.py
+++ b/python/lsst/ctrl/mpexec/reports.py
@@ -1,0 +1,173 @@
+# This file is part of ctrl_mpexec.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ["ExecutionStatus", "Report", "QuantumReport"]
+
+import enum
+import sys
+from typing import Dict, List, Optional
+
+from lsst.daf.butler import DataCoordinate, DataId, DataIdValue
+from lsst.utils.introspection import get_full_type_name
+from pydantic import BaseModel, validator
+
+
+def _serializeDataId(dataId: DataId) -> Dict[str, DataIdValue]:
+    if isinstance(dataId, DataCoordinate):
+        return dataId.byName()
+    else:
+        return dataId  # type: ignore
+
+
+class ExecutionStatus(enum.Enum):
+    """Possible values for job execution status.
+
+    Status `FAILURE` is set if one or more tasks failed. Status `TIMEOUT` is
+    set if there are no failures but one or more tasks timed out. Timeouts can
+    only be detected in multi-process mode, child task is killed on timeout
+    and usually should have non-zero exit code.
+    """
+
+    SUCCESS = "success"
+    FAILURE = "failure"
+    TIMEOUT = "timeout"
+    SKIPPED = "skipped"
+
+
+class ExceptionInfo(BaseModel):
+    """Information about exception."""
+
+    className: str
+    """Name of the exception class if exception was raised."""
+
+    message: str
+    """Exception message for in-process quantum execution, None if
+    quantum was executed in sub-process.
+    """
+
+    @classmethod
+    def from_exception(cls, exception: Exception) -> ExceptionInfo:
+        """Construct instance from an exception."""
+        return cls(className=get_full_type_name(exception), message=str(exception))
+
+
+class QuantumReport(BaseModel):
+    """Task execution report for a single Quantum."""
+
+    status: ExecutionStatus = ExecutionStatus.SUCCESS
+    """Execution status, one of the values in `ExecutionStatus` enum."""
+
+    dataId: Dict[str, DataIdValue]
+    """Quantum DataId."""
+
+    taskLabel: Optional[str]
+    """Label for a task executing this Quantum."""
+
+    exitCode: Optional[int] = None
+    """Exit code for a sub-process executing Quantum, None for in-process
+    Quantum execution. Negative if process was killed by a signal.
+    """
+
+    exceptionInfo: Optional[ExceptionInfo] = None
+    """Exception information if exception was raised."""
+
+    def __init__(
+        self,
+        dataId: DataId,
+        taskLabel: str,
+        status: ExecutionStatus = ExecutionStatus.SUCCESS,
+        exitCode: Optional[int] = None,
+        exceptionInfo: Optional[ExceptionInfo] = None,
+    ):
+        super().__init__(
+            status=status,
+            dataId=_serializeDataId(dataId),
+            taskLabel=taskLabel,
+            exitCode=exitCode,
+            exceptionInfo=exceptionInfo,
+        )
+
+    @classmethod
+    def from_exception(
+        cls,
+        exception: Exception,
+        dataId: DataId,
+        taskLabel: str,
+    ) -> QuantumReport:
+        """Construct report instance from an exception and other pieces of
+        data.
+        """
+        return cls(
+            status=ExecutionStatus.FAILURE,
+            dataId=dataId,
+            taskLabel=taskLabel,
+            exceptionInfo=ExceptionInfo.from_exception(exception),
+        )
+
+    @classmethod
+    def from_exit_code(
+        cls,
+        exitCode: int,
+        dataId: DataId,
+        taskLabel: str,
+    ) -> QuantumReport:
+        """Construct report instance from an exit code and other pieces of
+        data.
+        """
+        return cls(
+            status=ExecutionStatus.SUCCESS if exitCode == 0 else ExecutionStatus.FAILURE,
+            dataId=dataId,
+            taskLabel=taskLabel,
+            exitCode=exitCode,
+        )
+
+
+class Report(BaseModel):
+    """Execution report for the whole job with one or few quanta."""
+
+    status: ExecutionStatus = ExecutionStatus.SUCCESS
+    """Job status."""
+
+    cmdLine: Optional[List[str]] = None
+    """Command line for the whole job."""
+
+    exitCode: Optional[int] = None
+    """Job exit code, this obviously cannot be set in pipetask."""
+
+    exceptionInfo: Optional[ExceptionInfo] = None
+    """Exception information if exception was raised."""
+
+    quantaReports: List[QuantumReport] = []
+    """List of per-quantum reports, ordering is not specified. Some or all
+    quanta may not produce a report.
+    """
+
+    @validator("cmdLine", always=True)
+    def _set_cmdLine(cls, v: Optional[List[str]]) -> List[str]:  # noqa: N805
+        if v is None:
+            v = sys.argv
+        return v
+
+    def set_exception(self, exception: Exception) -> None:
+        """Update exception information from an exception object."""
+        self.exceptionInfo = ExceptionInfo.from_exception(exception)

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,0 +1,125 @@
+# This file is part of ctrl_mpexec.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+
+from lsst.ctrl.mpexec import ExecutionStatus, QuantumReport, Report
+
+
+class ReportsTestCase(unittest.TestCase):
+    """A test case for reports module"""
+
+    def test_quantumReport(self):
+        """Test for QuantumReport class"""
+
+        dataId = {"instrument": "LSST"}
+        taskLabel = "task"
+
+        qr = QuantumReport(dataId=dataId, taskLabel=taskLabel)
+        self.assertEqual(qr.status, ExecutionStatus.SUCCESS)
+        self.assertEqual(qr.dataId, dataId)
+        self.assertEqual(qr.taskLabel, taskLabel)
+        self.assertIsNone(qr.exitCode)
+        self.assertIsNone(qr.exceptionInfo)
+
+        qr = QuantumReport(status=ExecutionStatus.TIMEOUT, dataId=dataId, taskLabel=taskLabel)
+        self.assertEqual(qr.status, ExecutionStatus.TIMEOUT)
+
+        qr = QuantumReport.from_exception(
+            exception=RuntimeError("runtime error"), dataId=dataId, taskLabel=taskLabel
+        )
+        self.assertEqual(qr.status, ExecutionStatus.FAILURE)
+        self.assertEqual(qr.dataId, dataId)
+        self.assertEqual(qr.taskLabel, taskLabel)
+        self.assertIsNone(qr.exitCode)
+        self.assertEqual(qr.exceptionInfo.className, "RuntimeError")
+        self.assertEqual(qr.exceptionInfo.message, "runtime error")
+
+        qr = QuantumReport.from_exit_code(exitCode=0, dataId=dataId, taskLabel=taskLabel)
+        self.assertEqual(qr.status, ExecutionStatus.SUCCESS)
+        self.assertEqual(qr.dataId, dataId)
+        self.assertEqual(qr.taskLabel, taskLabel)
+        self.assertEqual(qr.exitCode, 0)
+        self.assertIsNone(qr.exceptionInfo)
+
+        qr = QuantumReport.from_exit_code(exitCode=1, dataId=dataId, taskLabel=taskLabel)
+        self.assertEqual(qr.status, ExecutionStatus.FAILURE)
+        self.assertEqual(qr.dataId, dataId)
+        self.assertEqual(qr.taskLabel, taskLabel)
+        self.assertEqual(qr.exitCode, 1)
+        self.assertIsNone(qr.exceptionInfo)
+
+    def test_report(self):
+        """Test for Report class"""
+
+        report = Report()
+        self.assertEqual(report.status, ExecutionStatus.SUCCESS)
+        self.assertIsNotNone(report.cmdLine)
+        self.assertIsNone(report.exitCode)
+        self.assertIsNone(report.exceptionInfo)
+
+        dataId = {"instrument": "LSST"}
+        taskLabel = "task"
+
+        qr = QuantumReport.from_exception(
+            exception=RuntimeError("runtime error"), dataId=dataId, taskLabel=taskLabel
+        )
+        report = Report(status=ExecutionStatus.FAILURE, exitCode=-1)
+        report.set_exception(RuntimeError("runtime error"))
+        report.quantaReports.append(qr)
+        self.assertEqual(report.status, ExecutionStatus.FAILURE)
+        self.assertEqual(report.exitCode, -1)
+        self.assertEqual(report.exceptionInfo.className, "RuntimeError")
+        self.assertEqual(report.exceptionInfo.message, "runtime error")
+        self.assertEqual(len(report.quantaReports), 1)
+
+    def test_json(self):
+        """Test for conversion to/from json"""
+
+        dataId = {"instrument": "LSST"}
+        taskLabel = "task"
+
+        qr = QuantumReport.from_exception(
+            exception=RuntimeError("runtime error"), dataId=dataId, taskLabel=taskLabel
+        )
+        report = Report(status=ExecutionStatus.FAILURE, exitCode=-1)
+        report.set_exception(RuntimeError("runtime error"))
+        report.quantaReports.append(qr)
+        json = report.json(exclude_none=True, indent=2)
+        self.assertIsInstance(json, str)
+
+        report = Report.parse_raw(json)
+        self.assertEqual(report.status, ExecutionStatus.FAILURE)
+        self.assertEqual(report.exitCode, -1)
+        self.assertEqual(report.exceptionInfo.className, "RuntimeError")
+        self.assertEqual(report.exceptionInfo.message, "runtime error")
+        self.assertEqual(len(report.quantaReports), 1)
+        qr = report.quantaReports[0]
+        self.assertEqual(qr.status, ExecutionStatus.FAILURE)
+        self.assertEqual(qr.dataId, dataId)
+        self.assertEqual(qr.taskLabel, taskLabel)
+        self.assertIsNone(qr.exitCode)
+        self.assertEqual(qr.exceptionInfo.className, "RuntimeError")
+        self.assertEqual(qr.exceptionInfo.message, "runtime error")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Added couple of pydantic data structures that contain data to save in
jobreport.json. `pipetask` adds a `--summary` option specifyng file
name for jobreport. Naturally pipetask cannot produce complete report,
in particular `exitCode` cannot be filled by the process before it
exits. Some post-processing of the generated file will be needed to
finalize it.

## Checklist

- [X] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
