### PR TITLE
DM-34215: Support dropping into debugger on exception

### DIFF
--- a/doc/changes/DM-34215.feature.rst
+++ b/doc/changes/DM-34215.feature.rst
@@ -1,0 +1,4 @@
+Replaced the unused ``--do-raise`` option with ``--pdb``,
+which drops the user into the debugger
+(``pdb`` by default, but ``--pdb=ipdb`` also works if you have ``ipdb`` installed)
+on an exception.

--- a/python/lsst/ctrl/mpexec/cli/opt/optionGroups.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/optionGroups.py
@@ -118,7 +118,7 @@ class execution_options(OptionGroup):  # noqa: N801
         self.decorators = [
             option_section(sectionText="Execution options:"),
             ctrlMpExecOpts.clobber_outputs_option(),
-            ctrlMpExecOpts.do_raise_option(),
+            ctrlMpExecOpts.pdb_option(),
             ctrlMpExecOpts.profile_option(),
             dafButlerOpts.processes_option(),
             ctrlMpExecOpts.start_method_option(),

--- a/python/lsst/ctrl/mpexec/cli/opt/options.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/options.py
@@ -76,8 +76,12 @@ delete_option = MWOptionDecorator(
 )
 
 
-do_raise_option = MWOptionDecorator(
-    "--do-raise", help="Raise an exception on error. (else log a message and continue?)", is_flag=True
+pdb_option = MWOptionDecorator(
+    "--pdb",
+    help="Post-mortem debugger to launch for exceptions (defaults to pdb if unspecified; requires a tty).",
+    is_flag=False,
+    flag_value="pdb",
+    default=None,
 )
 
 

--- a/python/lsst/ctrl/mpexec/cli/script/run.py
+++ b/python/lsst/ctrl/mpexec/cli/script/run.py
@@ -28,7 +28,7 @@ _log = logging.getLogger(__name__)
 
 
 def run(
-    do_raise,
+    pdb,
     graph_fixup,
     init_only,
     no_versions,
@@ -63,8 +63,8 @@ def run(
 
     Parameters
     ----------
-    do_raise : `bool`
-        Raise an exception in the case of an error.
+    pdb : `bool`
+        Drop into pdb on exception?
     graph_fixup : `str`
         The name of the class or factory method which makes an instance used
         for execution graph fixup.
@@ -154,7 +154,7 @@ def run(
         which ingore these unused kwargs.
     """
     args = SimpleNamespace(
-        do_raise=do_raise,
+        pdb=pdb,
         graph_fixup=graph_fixup,
         init_only=init_only,
         no_versions=no_versions,

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -729,6 +729,7 @@ class CmdLineFwk:
                 startMethod=args.start_method,
                 quantumExecutor=quantumExecutor,
                 failFast=args.fail_fast,
+                pdb=args.pdb,
                 executionGraphFixup=graphFixup,
             )
             try:


### PR DESCRIPTION
When we get an exception, sometimes it's not enough to just
see the backtrace, but we also want to get a debugger prompt
at the point of the exception.

Replaced the --do-raise option (apparently unused, and often
associated with getting a debugger with Gen2) with --pdb
(well-known and appreciated option from pytest), which causes
MPGraphExecutor._executeQuantaInProcess to drop into pdb.

## Checklist

- [ ] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
