### PR TITLE
DM-33493: Add datastore records to generated quantum graph

### DIFF
--- a/python/lsst/ctrl/mpexec/cli/opt/optionGroups.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/optionGroups.py
@@ -79,6 +79,7 @@ class qgraph_options(OptionGroup):  # noqa: N801
             ctrlMpExecOpts.qgraph_option(),
             ctrlMpExecOpts.qgraph_id_option(),
             ctrlMpExecOpts.qgraph_node_id_option(),
+            ctrlMpExecOpts.qgraph_datastore_records_option(),
             ctrlMpExecOpts.skip_existing_in_option(),
             ctrlMpExecOpts.skip_existing_option(),
             ctrlMpExecOpts.clobber_outputs_option(),

--- a/python/lsst/ctrl/mpexec/cli/opt/options.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/options.py
@@ -192,6 +192,17 @@ qgraph_id_option = MWOptionDecorator(
 )
 
 
+qgraph_datastore_records_option = MWOptionDecorator(
+    "--qgraph-datastore-records",
+    help=unwrap(
+        """Include datastore records into generated quantum graph, these records are used by a
+        quantum-backed butler.
+        """
+    ),
+    is_flag=True,
+)
+
+
 # I wanted to use default=None here to match Python API but click silently
 # replaces None with an empty tuple when multiple=True.
 qgraph_node_id_option = MWOptionDecorator(

--- a/python/lsst/ctrl/mpexec/cli/script/qgraph.py
+++ b/python/lsst/ctrl/mpexec/cli/script/qgraph.py
@@ -34,6 +34,7 @@ def qgraph(
     qgraph,
     qgraph_id,
     qgraph_node_id,
+    qgraph_datastore_records,
     skip_existing_in,
     skip_existing,
     save_qgraph,
@@ -73,6 +74,8 @@ def qgraph(
     qgraph_node_id : `list` of `int`, optional
         Only load a specified set of nodes if graph is loaded from a file,
         nodes are identified by integer IDs.
+    qgraph_datastore_records : `bool`
+        If True then include datastore records into generated quanta.
     skip_existing_in : `list` [ `str` ]
         Accepts list of collections, if all Quantum outputs already exist in
         the specified list of collections then that Quantum will be excluded
@@ -158,6 +161,7 @@ def qgraph(
         qgraph=qgraph,
         qgraph_id=qgraph_id,
         qgraph_node_id=qgraph_node_id,
+        qgraph_datastore_records=qgraph_datastore_records,
         save_qgraph=save_qgraph,
         save_single_quanta=save_single_quanta,
         qgraph_dot=qgraph_dot,


### PR DESCRIPTION
`pipetask` adds new command line option to enable storing of the dataset
records in quanta.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
