### PR TITLE
DM-33942: Use a dimensions version number that won't clash

### DIFF
--- a/tests/test_cmdLineFwk.py
+++ b/tests/test_cmdLineFwk.py
@@ -217,6 +217,7 @@ def _makeQGraph():
     config = Config(
         {
             "version": 1,
+            "namespace": "ctrl_mpexec_test",
             "skypix": {
                 "common": "htm7",
                 "htm": {


### PR DESCRIPTION
"1" is a valid upstream dimension version.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
