### PR TITLE
DM-33946: Add a namespace to the test universe configuration

### DIFF
--- a/tests/test_cmdLineFwk.py
+++ b/tests/test_cmdLineFwk.py
@@ -217,6 +217,7 @@ def _makeQGraph():
     config = Config(
         {
             "version": 1,
+            "namespace": "ctrl_mpexec_test",
             "skypix": {
                 "common": "htm7",
                 "htm": {


### PR DESCRIPTION
"1" is a valid upstream dimension version so the
namespace is needed to disambiguate.

Requires lsst/daf_butler#683

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
