### PR TITLE
DM-34811 Fix component linkages in pipeline dot render

### DIFF
--- a/doc/changes/DM-34811.bugfix.md
+++ b/doc/changes/DM-34811.bugfix.md
@@ -1,0 +1,1 @@
+Fixed a bug where dot graphs of pipelines did not correctly render edges between composite and component dataset types.

--- a/python/lsst/ctrl/mpexec/dotTools.py
+++ b/python/lsst/ctrl/mpexec/dotTools.py
@@ -32,7 +32,7 @@ __all__ = ["graph2dot", "pipeline2dot"]
 # -----------------------------
 #  Imports for other modules --
 # -----------------------------
-from lsst.daf.butler import DimensionUniverse
+from lsst.daf.butler import DatasetType, DimensionUniverse
 from lsst.pipe.base import Pipeline, iterConnections
 
 # ----------------------------------
@@ -244,7 +244,13 @@ def pipeline2dot(pipeline, file):
                 dimensions = expand_dimensions(attr.dimensions)
                 _renderDSTypeNode(attr.name, dimensions, file)
                 allDatasets.add(attr.name)
+            nodeName, component = DatasetType.splitDatasetTypeName(attr.name)
             _renderEdge(attr.name, taskNodeName, file)
+            # connect component dataset types to the composite type that
+            # produced it
+            if component is not None and (nodeName, attr.name) not in allDatasets:
+                _renderEdge(nodeName, attr.name, file)
+                allDatasets.add((nodeName, attr.name))
 
         for attr in iterConnections(taskDef.connections, "prerequisiteInputs"):
             if attr.name not in allDatasets:

--- a/python/lsst/ctrl/mpexec/dotTools.py
+++ b/python/lsst/ctrl/mpexec/dotTools.py
@@ -236,7 +236,7 @@ def pipeline2dot(pipeline, file):
         pipeline = pipeline.toExpandedPipeline()
 
     # The next two lines are a workaround until DM-29658 at which time metadata
-    # connections should star working with the above code
+    # connections should start working with the above code
     labelToTaskName = {}
     metadataNodesToLink = set()
 
@@ -250,6 +250,7 @@ def pipeline2dot(pipeline, file):
 
         _renderTaskNode(taskNodeName, taskDef, file, None)
 
+        metadataRePattern = re.compile("^(.*)_metadata$")
         for attr in sorted(iterConnections(taskDef.connections, "inputs"), key=lambda x: x.name):
             if attr.name not in allDatasets:
                 dimensions = expand_dimensions(attr.dimensions)
@@ -266,8 +267,8 @@ def pipeline2dot(pipeline, file):
                     dimensions = expand_dimensions(attr.dimensions)
                     _renderDSTypeNode(nodeName, dimensions, file)
             # The next if block is a workaround until DM-29658 at which time
-            # metadata connections should star working with the above code
-            if (match := re.match("^(.*)_metadata$", attr.name)) is not None:
+            # metadata connections should start working with the above code
+            if (match := metadataRePattern.match(attr.name)) is not None:
                 matchTaskLabel = match.group(1)
                 metadataNodesToLink.add((matchTaskLabel, attr.name))
 
@@ -287,7 +288,7 @@ def pipeline2dot(pipeline, file):
             _renderEdge(taskNodeName, attr.name, file)
 
     # This for loop is a workaround until DM-29658 at which time metadata
-    # connections should star working with the above code
+    # connections should start working with the above code
     for matchLabel, dsTypeName in metadataNodesToLink:
         # only render an edge to metadata if the label is part of the current
         # graph

--- a/tests/test_dotTools.py
+++ b/tests/test_dotTools.py
@@ -114,7 +114,13 @@ class DotToolsTestCase(unittest.TestCase):
     def testPipeline2dot(self):
         """Tests for dotTools.pipeline2dot method"""
         pipeline = _makePipeline(
-            [("A", ("B", "C"), "task1"), ("C", "E", "task2"), ("B", "D", "task3"), (("D", "E"), "F", "task4")]
+            [
+                ("A", ("B", "C"), "task1"),
+                ("C", "E", "task2"),
+                ("B", "D", "task3"),
+                (("D", "E"), "F", "task4"),
+                ("D.C", "G", "task5"),
+            ]
         )
         file = io.StringIO()
         pipeline2dot(pipeline, file)
@@ -122,9 +128,9 @@ class DotToolsTestCase(unittest.TestCase):
         # It's hard to validate complete output, just checking few basic
         # things, even that is not terribly stable.
         lines = file.getvalue().strip().split("\n")
-        ndatasets = 6
-        ntasks = 4
-        nedges = 10
+        ndatasets = 8
+        ntasks = 5
+        nedges = 13
         nextra = 2  # graph header and closing
         self.assertEqual(len(lines), ndatasets + ntasks + nedges + nextra)
 
@@ -143,6 +149,9 @@ class DotToolsTestCase(unittest.TestCase):
                     node = match.group(group)
                     self.assertEqual(node[0] + node[-1], '""')
                 continue
+
+        # make sure components are connected appropriately
+        self.assertIn('"D" -> "D.C";', file.getvalue())
 
 
 class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_dotTools.py
+++ b/tests/test_dotTools.py
@@ -115,11 +115,12 @@ class DotToolsTestCase(unittest.TestCase):
         """Tests for dotTools.pipeline2dot method"""
         pipeline = _makePipeline(
             [
-                ("A", ("B", "C"), "task1"),
-                ("C", "E", "task2"),
-                ("B", "D", "task3"),
-                (("D", "E"), "F", "task4"),
-                ("D.C", "G", "task5"),
+                ("A", ("B", "C"), "task0"),
+                ("C", "E", "task1"),
+                ("B", "D", "task2"),
+                (("D", "E"), "F", "task3"),
+                ("D.C", "G", "task4"),
+                ("task3_metadata", "H", "task5"),
             ]
         )
         file = io.StringIO()
@@ -128,9 +129,9 @@ class DotToolsTestCase(unittest.TestCase):
         # It's hard to validate complete output, just checking few basic
         # things, even that is not terribly stable.
         lines = file.getvalue().strip().split("\n")
-        ndatasets = 8
-        ntasks = 5
-        nedges = 13
+        ndatasets = 10
+        ntasks = 6
+        nedges = 16
         nextra = 2  # graph header and closing
         self.assertEqual(len(lines), ndatasets + ntasks + nedges + nextra)
 
@@ -152,6 +153,10 @@ class DotToolsTestCase(unittest.TestCase):
 
         # make sure components are connected appropriately
         self.assertIn('"D" -> "D.C";', file.getvalue())
+
+        # make sure there is a connection created for metadata if someone
+        # tries to read it in
+        self.assertIn('"task3" -> "task3_metadata"', file.getvalue())
 
 
 class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):


### PR DESCRIPTION
Creating a dot graph was previously not correctly linking component
datasets to the composite that provided them when drawing a graph,
this ensures the linkages are added appropriately.

## Checklist

- [ x ] ran Jenkins
- [ x ] added a release note for user-visible changes to `doc/changes`
