### PR TITLE
DM-33488: Update for changes in pruneDatasets interface

### DIFF
--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -394,7 +394,7 @@ class _ButlerFactory:
                         if taskDefs is not None:
                             initDatasetNames = set(PipelineDatasetTypes.initOutputNames(taskDefs))
                             refs = [ref for ref in refs if ref.datasetType.name not in initDatasetNames]
-                        butler.pruneDatasets(refs, unstore=True, run=replaced, disassociate=False)
+                        butler.pruneDatasets(refs, unstore=True, disassociate=False)
                 elif args.prune_replaced == "purge":
                     # Erase entire collection and all datasets, need to remove
                     # collection from its chain collection first.

--- a/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
+++ b/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
@@ -421,16 +421,7 @@ class SingleQuantumExecutor(QuantumExecutor):
                 if self.clobberOutputs:
                     # only prune
                     _LOG.info("Removing partial outputs for task %s: %s", taskDef, existingRefs)
-                    # Do not purge registry records if this looks like
-                    # an execution butler. This ensures that the UUID
-                    # of the dataset doesn't change.
-                    if butler._allow_put_of_predefined_dataset:
-                        purge = False
-                        disassociate = False
-                    else:
-                        purge = True
-                        disassociate = True
-                    butler.pruneDatasets(existingRefs, disassociate=disassociate, unstore=True, purge=purge)
+                    butler.pruneDatasets(existingRefs, disassociate=True, unstore=True, purge=True)
                     return False
                 else:
                     raise RuntimeError(

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ tests_require =
 where=python
 
 [options.package_data]
-lsst.pipe.base = py.typed
+lsst.ctrl.mpexec = py.typed
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
The `pruneDatasets` Butler method dropped `run` argument, removing it
from the client side. Execution butler logic is now handled internally
in the same method, removing this logic from caller.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
