### PR TITLE
DM-35153: Fix collection order in SimplePipelineExecutor

### DIFF
--- a/python/lsst/ctrl/mpexec/simple_pipeline_executor.py
+++ b/python/lsst/ctrl/mpexec/simple_pipeline_executor.py
@@ -105,8 +105,8 @@ class SimplePipelineExecutor:
         butler = Butler(root, writeable=True)
         butler.registry.registerCollection(output_run, CollectionType.RUN)
         butler.registry.registerCollection(output, CollectionType.CHAINED)
-        collections = list(inputs)
-        collections.append(output_run)
+        collections = [output_run]
+        collections.extend(inputs)
         butler.registry.setCollectionChain(output, collections)
         # Remake butler to let it infer default data IDs from collections, now
         # that those collections exist.


### PR DESCRIPTION
The output collection should be first in the list of collections, not last.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
