### PR TITLE
DM-36360: Improve diagnostic visibility for empty QGs.

### DIFF
--- a/python/lsst/ctrl/mpexec/cli/cmd/commands.py
+++ b/python/lsst/ctrl/mpexec/cli/cmd/commands.py
@@ -137,7 +137,8 @@ def qgraph(ctx: click.Context, **kwargs: Any) -> None:
             file=sys.stderr,
         )
         return
-    script.qgraph(pipelineObj=pipeline, **kwargs, show=show)
+    if script.qgraph(pipelineObj=pipeline, **kwargs, show=show) is None:
+        raise click.ClickException("QuantumGraph was empty; CRITICAL logs above should provide details.")
     _unhandledShow(show, "qgraph")
 
 
@@ -156,7 +157,8 @@ def run(ctx: click.Context, **kwargs: Any) -> None:
             file=sys.stderr,
         )
         return
-    qgraph = script.qgraph(pipelineObj=pipeline, **kwargs, show=show)
+    if (qgraph := script.qgraph(pipelineObj=pipeline, **kwargs, show=show)) is None:
+        raise click.ClickException("QuantumGraph was empty; CRITICAL logs above should provide details.")
     _unhandledShow(show, "run")
     if show.handled:
         print(

--- a/python/lsst/ctrl/mpexec/cli/script/qgraph.py
+++ b/python/lsst/ctrl/mpexec/cli/script/qgraph.py
@@ -196,7 +196,7 @@ def qgraph(  # type: ignore
     qgraph = f.makeGraph(pipelineObj, args)
 
     if qgraph is None:
-        raise RuntimeError("QuantumGraph is empty.")
+        return None
 
     # optionally dump some info.
     show.show_graph_info(qgraph, args)

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -33,7 +33,6 @@ import copy
 import datetime
 import getpass
 import logging
-import warnings
 from types import SimpleNamespace
 from typing import Iterable, Optional, Tuple
 
@@ -575,7 +574,6 @@ class CmdLineFwk:
         # None.
         nQuanta = len(qgraph)
         if nQuanta == 0:
-            warnings.warn("QuantumGraph is empty", stacklevel=2)
             return None
         else:
             _LOG.info(

--- a/python/lsst/ctrl/mpexec/mpGraphExecutor.py
+++ b/python/lsst/ctrl/mpexec/mpGraphExecutor.py
@@ -32,7 +32,7 @@ import signal
 import sys
 import time
 from enum import Enum
-from typing import TYPE_CHECKING, Iterable, Optional
+from typing import TYPE_CHECKING, Iterable, Literal, Optional
 
 from lsst.daf.butler.cli.cliLog import CliLog
 from lsst.pipe.base import InvalidQuantumError, TaskDef
@@ -92,7 +92,10 @@ class _Job:
         return False
 
     def start(
-        self, butler: Butler, quantumExecutor: QuantumExecutor, startMethod: Optional[str] = None
+        self,
+        butler: Butler,
+        quantumExecutor: QuantumExecutor,
+        startMethod: Literal["spawn"] | Literal["fork"] | Literal["forkserver"] | None = None,
     ) -> None:
         """Start process which runs the task.
 
@@ -256,7 +259,11 @@ class _JobList:
         self.timedOutNodes: set[QuantumNode] = set()
 
     def submit(
-        self, job: _Job, butler: Butler, quantumExecutor: QuantumExecutor, startMethod: Optional[str] = None
+        self,
+        job: _Job,
+        butler: Butler,
+        quantumExecutor: QuantumExecutor,
+        startMethod: Literal["spawn"] | Literal["fork"] | Literal["forkserver"] | None = None,
     ) -> None:
         """Submit one more job for execution
 
@@ -370,7 +377,7 @@ class MPGraphExecutor(QuantumGraphExecutor):
         timeout: float,
         quantumExecutor: QuantumExecutor,
         *,
-        startMethod: Optional[str] = None,
+        startMethod: Literal["spawn"] | Literal["fork"] | Literal["forkserver"] | None = None,
         failFast: bool = False,
         pdb: Optional[str] = None,
         executionGraphFixup: Optional[ExecutionGraphFixup] = None,
@@ -387,7 +394,7 @@ class MPGraphExecutor(QuantumGraphExecutor):
         # None for all other platforms to use multiprocessing default.
         if startMethod is None:
             methods = dict(linux="fork", darwin="spawn")
-            startMethod = methods.get(sys.platform)
+            startMethod = methods.get(sys.platform)  # type: ignore
         self.startMethod = startMethod
 
     def execute(self, graph: QuantumGraph, butler: Butler) -> None:


### PR DESCRIPTION
By moving the exception raise down to the outer click layer (returning None through all higher layers) we avoid the long traceback that hides the useful information being logged by pipe_base.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes` (in pipe_base)

I expect the `build_and_test` check here to fail until the pipe_base is branch is merged.