### PR TITLE
DM-37450: Fix text with faulty expectations.

### DIFF
--- a/python/lsst/ctrl/mpexec/cli/utils.py
+++ b/python/lsst/ctrl/mpexec/cli/utils.py
@@ -148,4 +148,4 @@ def makePipelineActions(
 class PipetaskCommand(MWCommand):
     """Command subclass with pipetask-command specific overrides."""
 
-    extra_epilog = "See 'pipetask --help' for more options."  # type: ignore
+    extra_epilog = "See 'pipetask --help' for more options."

--- a/tests/test_simple_pipeline_executor.py
+++ b/tests/test_simple_pipeline_executor.py
@@ -219,12 +219,10 @@ class SimplePipelineExecutorTests(lsst.utils.tests.TestCase):
         # A returns a dict because it has not been told to do anything else.
         # That does not match the storage class so it will be converted
         # on put.
-        # b is given a TaskMetadata.
+        # b is given a dict, because that's what its connection asks for.
         # b returns a TaskMetadata because that's how we configured it, but
         # the butler expects a dict so it is converted on put.
-        self._test_logs(
-            cm.output, "dict", "dict", "lsst.pipe.base.TaskMetadata", "lsst.pipe.base.TaskMetadata"
-        )
+        self._test_logs(cm.output, "dict", "dict", "dict", "lsst.pipe.base.TaskMetadata")
 
         self.assertEqual(len(quanta), 2)
         self.assertEqual(self.butler.get("intermediate").to_dict(), {"zero": 0, "one": 1})


### PR DESCRIPTION
New butler code causes the storage class in the DatasetType passed to findDataset to be respected, which causes the storage class in the input connection to be respected.

Relies on lsst/daf_butler#766

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
