### PR TITLE
DM-37582: Always resolve dataset refs in generated graph

### DIFF
--- a/doc/changes/DM-37582.feature.rst
+++ b/doc/changes/DM-37582.feature.rst
@@ -1,0 +1,1 @@
+`pipetask` will now produce QuantumGraph with resolved output references, even with execution butler option.

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -588,8 +588,6 @@ class CmdLineFwk:
                 "user": getpass.getuser(),
                 "time": f"{datetime.datetime.now()}",
             }
-            # Execution butler builder relies on non-resolved output refs.
-            resolve_refs = not args.execution_butler_location
             qgraph = graphBuilder.makeGraph(
                 pipeline,
                 collections,
@@ -597,7 +595,7 @@ class CmdLineFwk:
                 args.data_query,
                 metadata=metadata,
                 datasetQueryConstraint=args.dataset_query_constraint,
-                resolveRefs=resolve_refs,
+                resolveRefs=True,
             )
             if args.show_qgraph_header:
                 qgraph.buildAndPrintHeader()


### PR DESCRIPTION
Execution butler builder is updated (on this ticket) to support resolved refs for outputs. This allows us to always resolve all refs in generated graphs.

Depends on lsst/pipe_base#299

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
