### PR TITLE
DM-38165: Suppress traceback for a crashing task in unit test

### DIFF
--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -22,6 +22,7 @@
 """Simple unit test for cmdLineFwk module.
 """
 
+import faulthandler
 import logging
 import signal
 import sys
@@ -186,6 +187,8 @@ class TaskMockCrash:
 
     def runQuantum(self):
         _LOG.debug("TaskMockCrash.runQuantum")
+        # Disable fault handler to suppress long scary traceback.
+        faulthandler.disable()
         signal.raise_signal(signal.SIGILL)
 
 


### PR DESCRIPTION
Apparently `faulthandler` is now enabled by default (which is a good thing in general) and it prints a long confusing traceback for the unit test that uses signal to kill a task. Disabling `faulthandler` in that task is sufficient to suppress traceback.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
