### PR TITLE
DM-38601: Fix checkExistingOutputs method to clobber complete outputs

### DIFF
--- a/doc/changes/DM-38601.bugfix.md
+++ b/doc/changes/DM-38601.bugfix.md
@@ -1,0 +1,2 @@
+Fixed `SingleQuantumExecutor` class to correctly handle the case with `clobberOutputs=True` and `skipExistingIn=None`.
+Documentation says that complete quantum outputs should be removed in this case, but they were not removed.


### PR DESCRIPTION
The logic in the method has been improved to handle the case when
clobberOutputs was specified without skipExistingIn. It now correctly
removes complete quantum outputs. Added test cases for this behavior.

## Checklist

- [X] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
