### PR TITLE
DM-36162: Implement SeparablePipelineExecutor

### DIFF
--- a/doc/changes/DM-36162.feature.md
+++ b/doc/changes/DM-36162.feature.md
@@ -1,0 +1,3 @@
+Added SeparablePipelineExecutor, a pipeline executor midway in capability between SimplePipelineExecutor and CmdLineFwk.
+SeparablePipelineExecutor is designed to be run from Python, and lets the caller decide when each pipeline processing step is carried out.
+It also allows certain pipeline steps to be customized by passing alternate implementations of execution strategies (e.g., custom graph builder).

--- a/python/lsst/ctrl/mpexec/__init__.py
+++ b/python/lsst/ctrl/mpexec/__init__.py
@@ -26,6 +26,7 @@ from .mpGraphExecutor import *
 from .preExecInit import *
 from .quantumGraphExecutor import *
 from .reports import *
+from .separablePipelineExecutor import *
 from .simple_pipeline_executor import *
 from .singleQuantumExecutor import *
 from .taskFactory import *

--- a/python/lsst/ctrl/mpexec/separablePipelineExecutor.py
+++ b/python/lsst/ctrl/mpexec/separablePipelineExecutor.py
@@ -1,0 +1,86 @@
+# This file is part of ctrl_mpexec.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from __future__ import annotations
+
+__all__ = [
+    "SeparablePipelineExecutor",
+]
+
+
+from typing import Iterable
+
+import lsst.pipe.base
+from lsst.daf.butler import Butler
+
+from .taskFactory import TaskFactory
+
+
+class SeparablePipelineExecutor:
+    """An executor that allows each step of pipeline execution to be
+    run independently.
+
+    The executor can run any or all of the following steps:
+
+        * pre-execution initialization
+        * pipeline building
+        * quantum graph generation
+        * quantum graph execution
+
+    Any of these steps can also be handed off to external code without
+    compromising the remaining ones.
+
+    Parameters
+    ----------
+    butler : `lsst.daf.butler.Butler`
+        A Butler whose ``collections`` and ``run`` attributes contain the input
+        and output collections to use for processing.
+    clobber_output : `bool`, optional
+        If set, the pipeline execution overwrites existing output files.
+        Otherwise, any conflict between existing and new outputs is an error.
+    skip_existing_in : iterable [`str`], optional
+        If not empty, the pipeline execution searches the listed collections
+        for existing outputs, and skips any quanta that have run to completion
+        (or have no work to do). Otherwise, all tasks are attempted (subject
+        to ``clobber_output``).
+    task_factory : `lsst.pipe.base.TaskFactory`, optional
+        A custom task factory for use in pre-execution and execution. By
+        default, a new instance of `lsst.ctrl.mpexec.TaskFactory` is used.
+    """
+
+    def __init__(
+        self,
+        butler: Butler,
+        clobber_output: bool = False,
+        skip_existing_in: Iterable[str] | None = None,
+        task_factory: lsst.pipe.base.TaskFactory | None = None,
+    ):
+        self._butler = Butler(butler=butler, collections=butler.collections, run=butler.run)
+        if not self._butler.collections:
+            raise ValueError("Butler must specify input collections for pipeline.")
+        if not self._butler.run:
+            raise ValueError("Butler must specify output run for pipeline.")
+
+        self._clobber_output = clobber_output
+        self._skip_existing_in = list(skip_existing_in) if skip_existing_in else []
+
+        self._task_factory = task_factory if task_factory else TaskFactory()

--- a/python/lsst/ctrl/mpexec/separablePipelineExecutor.py
+++ b/python/lsst/ctrl/mpexec/separablePipelineExecutor.py
@@ -30,6 +30,7 @@ __all__ = [
 from typing import Iterable
 
 import lsst.pipe.base
+import lsst.resources
 from lsst.daf.butler import Butler
 
 from .taskFactory import TaskFactory
@@ -84,3 +85,20 @@ class SeparablePipelineExecutor:
         self._skip_existing_in = list(skip_existing_in) if skip_existing_in else []
 
         self._task_factory = task_factory if task_factory else TaskFactory()
+
+    def make_pipeline(self, pipeline_uri: str | lsst.resources.ResourcePath) -> lsst.pipe.base.Pipeline:
+        """Build a pipeline from pipeline and configuration information.
+
+        Parameters
+        ----------
+        pipeline_uri : `str` or `lsst.resources.ResourcePath`
+            URI to a file containing a pipeline definition. A URI fragment may
+            be used to specify a subset of the pipeline, as described in
+            :ref:`pipeline-running-intro`.
+
+        Returns
+        -------
+        pipeline : `lsst.pipe.base.Pipeline`
+            The fully-built pipeline.
+        """
+        return lsst.pipe.base.Pipeline.from_uri(pipeline_uri)

--- a/tests/pipeline_separable.yaml
+++ b/tests/pipeline_separable.yaml
@@ -1,0 +1,12 @@
+description: test pipeline for tests/test_separablePipelineExecutor.py
+tasks:
+    a:
+        class: "lsst.pipe.base.tests.no_dimensions.NoDimensionsTestTask"
+        config:
+            connections.output: "intermediate"
+    b:
+        class: "lsst.pipe.base.tests.no_dimensions.NoDimensionsTestTask"
+        config:
+            connections.input: "intermediate"
+            key: "two"
+            value: 2

--- a/tests/test_separablePipelineExecutor.py
+++ b/tests/test_separablePipelineExecutor.py
@@ -25,9 +25,10 @@ import tempfile
 import unittest
 
 import lsst.daf.butler
+import lsst.daf.butler.tests as butlerTests
 import lsst.utils.tests
 from lsst.ctrl.mpexec import SeparablePipelineExecutor
-from lsst.pipe.base import Instrument
+from lsst.pipe.base import Instrument, Pipeline, TaskMetadata
 from lsst.resources import ResourcePath
 
 TESTDIR = os.path.abspath(os.path.dirname(__file__))
@@ -57,14 +58,13 @@ class SeparablePipelineExecutorTests(lsst.utils.tests.TestCase):
         butler.registry.setCollectionChain(output, [output_run])
         self.butler = lsst.daf.butler.Butler(butler=butler, collections=[output], run=output_run)
 
-        self.butler.registry.registerDatasetType(
-            lsst.daf.butler.DatasetType(
-                "input",
-                dimensions=self.butler.registry.dimensions.empty,
-                storageClass="StructuredDataDict",
-            )
-        )
-        self.butler.put({"zero": 0}, "input")
+        butlerTests.addDatasetType(self.butler, "input", set(), "StructuredDataDict")
+        butlerTests.addDatasetType(self.butler, "intermediate", set(), "StructuredDataDict")
+        butlerTests.addDatasetType(self.butler, "output", set(), "StructuredDataDict")
+        butlerTests.addDatasetType(self.butler, "a_log", set(), "ButlerLogRecords")
+        butlerTests.addDatasetType(self.butler, "a_metadata", set(), "TaskMetadata")
+        butlerTests.addDatasetType(self.butler, "b_log", set(), "ButlerLogRecords")
+        butlerTests.addDatasetType(self.butler, "b_metadata", set(), "TaskMetadata")
 
     def test_init_badinput(self):
         butler = lsst.daf.butler.Butler(butler=self.butler, collections=[], run="foo")
@@ -100,6 +100,183 @@ class SeparablePipelineExecutorTests(lsst.utils.tests.TestCase):
             pipeline = executor.make_pipeline(uri)
             self.assertEqual(len(pipeline), 1)
             self.assertEqual({t.label for t in pipeline}, {"a"})
+
+    def test_make_quantum_graph_nowhere_noskip_noclobber(self):
+        executor = SeparablePipelineExecutor(self.butler, skip_existing_in=None, clobber_output=False)
+        pipeline = Pipeline.fromFile(self.pipeline_file)
+
+        self.butler.put({"zero": 0}, "input")
+
+        graph = executor.make_quantum_graph(pipeline)
+        self.assertTrue(graph.isConnected)
+        self.assertEqual(len(graph), 2)
+        self.assertEqual({q.taskDef.label for q in graph.inputQuanta}, {"a"})
+        self.assertEqual({q.taskDef.label for q in graph.outputQuanta}, {"b"})
+
+    def test_make_quantum_graph_nowhere_noskip_noclobber_conflict(self):
+        executor = SeparablePipelineExecutor(self.butler, skip_existing_in=None, clobber_output=False)
+        pipeline = Pipeline.fromFile(self.pipeline_file)
+
+        self.butler.put({"zero": 0}, "input")
+        self.butler.put({"zero": 0}, "intermediate")
+        self.butler.put(lsst.daf.butler.ButlerLogRecords.from_records([]), "a_log")
+        self.butler.put(TaskMetadata(), "a_metadata")
+
+        with self.assertRaises(lsst.pipe.base.graphBuilder.OutputExistsError):
+            executor.make_quantum_graph(pipeline)
+
+    # TODO: need more complex task and Butler to test
+    # make_quantum_graph(where=...)
+
+    def test_make_quantum_graph_nowhere_skipnone_noclobber(self):
+        executor = SeparablePipelineExecutor(
+            self.butler,
+            skip_existing_in=[self.butler.run],
+            clobber_output=False,
+        )
+        pipeline = Pipeline.fromFile(self.pipeline_file)
+
+        self.butler.put({"zero": 0}, "input")
+
+        graph = executor.make_quantum_graph(pipeline)
+        self.assertTrue(graph.isConnected)
+        self.assertEqual(len(graph), 2)
+        self.assertEqual({q.taskDef.label for q in graph.inputQuanta}, {"a"})
+        self.assertEqual({q.taskDef.label for q in graph.outputQuanta}, {"b"})
+
+    def test_make_quantum_graph_nowhere_skiptotal_noclobber(self):
+        executor = SeparablePipelineExecutor(
+            self.butler,
+            skip_existing_in=[self.butler.run],
+            clobber_output=False,
+        )
+        pipeline = Pipeline.fromFile(self.pipeline_file)
+
+        self.butler.put({"zero": 0}, "input")
+        self.butler.put({"zero": 0}, "intermediate")
+        self.butler.put(lsst.daf.butler.ButlerLogRecords.from_records([]), "a_log")
+        self.butler.put(TaskMetadata(), "a_metadata")
+
+        graph = executor.make_quantum_graph(pipeline)
+        self.assertTrue(graph.isConnected)
+        self.assertEqual(len(graph), 1)
+        self.assertEqual({q.taskDef.label for q in graph.inputQuanta}, {"b"})
+        self.assertEqual({q.taskDef.label for q in graph.outputQuanta}, {"b"})
+
+    def test_make_quantum_graph_nowhere_skippartial_noclobber(self):
+        executor = SeparablePipelineExecutor(
+            self.butler,
+            skip_existing_in=[self.butler.run],
+            clobber_output=False,
+        )
+        pipeline = Pipeline.fromFile(self.pipeline_file)
+
+        self.butler.put({"zero": 0}, "input")
+        self.butler.put({"zero": 0}, "intermediate")
+
+        with self.assertRaises(lsst.pipe.base.graphBuilder.OutputExistsError):
+            executor.make_quantum_graph(pipeline)
+
+    def test_make_quantum_graph_nowhere_noskip_clobber(self):
+        executor = SeparablePipelineExecutor(self.butler, skip_existing_in=None, clobber_output=True)
+        pipeline = Pipeline.fromFile(self.pipeline_file)
+
+        self.butler.put({"zero": 0}, "input")
+
+        graph = executor.make_quantum_graph(pipeline)
+        self.assertTrue(graph.isConnected)
+        self.assertEqual(len(graph), 2)
+        self.assertEqual({q.taskDef.label for q in graph.inputQuanta}, {"a"})
+        self.assertEqual({q.taskDef.label for q in graph.outputQuanta}, {"b"})
+
+    def test_make_quantum_graph_nowhere_noskip_clobber_conflict(self):
+        executor = SeparablePipelineExecutor(self.butler, skip_existing_in=None, clobber_output=True)
+        pipeline = Pipeline.fromFile(self.pipeline_file)
+
+        self.butler.put({"zero": 0}, "input")
+        self.butler.put({"zero": 0}, "intermediate")
+        self.butler.put(lsst.daf.butler.ButlerLogRecords.from_records([]), "a_log")
+        self.butler.put(TaskMetadata(), "a_metadata")
+
+        graph = executor.make_quantum_graph(pipeline)
+        self.assertFalse(graph.isConnected)  # Both tasks run, but can use old values for b
+        self.assertEqual(len(graph), 2)
+        self.assertEqual({q.taskDef.label for q in graph.inputQuanta}, {"a", "b"})
+        self.assertEqual({q.taskDef.label for q in graph.outputQuanta}, {"a", "b"})
+
+    def test_make_quantum_graph_nowhere_skipnone_clobber(self):
+        executor = SeparablePipelineExecutor(
+            self.butler,
+            skip_existing_in=[self.butler.run],
+            clobber_output=True,
+        )
+        pipeline = Pipeline.fromFile(self.pipeline_file)
+
+        self.butler.put({"zero": 0}, "input")
+
+        graph = executor.make_quantum_graph(pipeline)
+        self.assertTrue(graph.isConnected)
+        self.assertEqual(len(graph), 2)
+        self.assertEqual({q.taskDef.label for q in graph.inputQuanta}, {"a"})
+        self.assertEqual({q.taskDef.label for q in graph.outputQuanta}, {"b"})
+
+    def test_make_quantum_graph_nowhere_skiptotal_clobber(self):
+        executor = SeparablePipelineExecutor(
+            self.butler,
+            skip_existing_in=[self.butler.run],
+            clobber_output=True,
+        )
+        pipeline = Pipeline.fromFile(self.pipeline_file)
+
+        self.butler.put({"zero": 0}, "input")
+        self.butler.put({"zero": 0}, "intermediate")
+        self.butler.put(lsst.daf.butler.ButlerLogRecords.from_records([]), "a_log")
+        self.butler.put(TaskMetadata(), "a_metadata")
+
+        graph = executor.make_quantum_graph(pipeline)
+        self.assertTrue(graph.isConnected)
+        self.assertEqual(len(graph), 1)
+        self.assertEqual({q.taskDef.label for q in graph.inputQuanta}, {"b"})
+        self.assertEqual({q.taskDef.label for q in graph.outputQuanta}, {"b"})
+
+    def test_make_quantum_graph_nowhere_skippartial_clobber(self):
+        executor = SeparablePipelineExecutor(
+            self.butler,
+            skip_existing_in=[self.butler.run],
+            clobber_output=True,
+        )
+        pipeline = Pipeline.fromFile(self.pipeline_file)
+
+        self.butler.put({"zero": 0}, "input")
+        self.butler.put({"zero": 0}, "intermediate")
+
+        graph = executor.make_quantum_graph(pipeline)
+        self.assertFalse(graph.isConnected)  # Both tasks run, but can use old values for b
+        self.assertEqual(len(graph), 2)
+        self.assertEqual({q.taskDef.label for q in graph.inputQuanta}, {"a", "b"})
+        self.assertEqual({q.taskDef.label for q in graph.outputQuanta}, {"a", "b"})
+
+    def test_make_quantum_graph_noinput(self):
+        executor = SeparablePipelineExecutor(self.butler)
+        pipeline = Pipeline.fromFile(self.pipeline_file)
+
+        graph = executor.make_quantum_graph(pipeline)
+        self.assertEqual(len(graph), 0)
+
+    def test_make_quantum_graph_alloutput_skip(self):
+        executor = SeparablePipelineExecutor(self.butler, skip_existing_in=[self.butler.run])
+        pipeline = Pipeline.fromFile(self.pipeline_file)
+
+        self.butler.put({"zero": 0}, "input")
+        self.butler.put({"zero": 0}, "intermediate")
+        self.butler.put(lsst.daf.butler.ButlerLogRecords.from_records([]), "a_log")
+        self.butler.put(TaskMetadata(), "a_metadata")
+        self.butler.put({"zero": 0}, "output")
+        self.butler.put(lsst.daf.butler.ButlerLogRecords.from_records([]), "b_log")
+        self.butler.put(TaskMetadata(), "b_metadata")
+
+        graph = executor.make_quantum_graph(pipeline)
+        self.assertEqual(len(graph), 0)
 
 
 class MemoryTester(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_separablePipelineExecutor.py
+++ b/tests/test_separablePipelineExecutor.py
@@ -1,0 +1,89 @@
+# This file is part of ctrl_mpexec.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+import os
+import tempfile
+import unittest
+
+import lsst.daf.butler
+import lsst.utils.tests
+from lsst.ctrl.mpexec import SeparablePipelineExecutor
+from lsst.pipe.base import Instrument
+
+TESTDIR = os.path.abspath(os.path.dirname(__file__))
+
+
+class SeparablePipelineExecutorTests(lsst.utils.tests.TestCase):
+    """Test the SeparablePipelineExecutor API with a trivial task."""
+
+    def setUp(self):
+        repodir = tempfile.TemporaryDirectory()
+        # TemporaryDirectory warns on leaks; addCleanup also keeps it from
+        # getting garbage-collected.
+        self.addCleanup(tempfile.TemporaryDirectory.cleanup, repodir)
+
+        # standalone parameter forces the returned config to also include
+        # the information from the search paths.
+        config = lsst.daf.butler.Butler.makeRepo(
+            repodir.name, standalone=True, searchPaths=[os.path.join(TESTDIR, "config")]
+        )
+        butler = lsst.daf.butler.Butler(config, writeable=True)
+        output = "fake"
+        output_run = f"{output}/{Instrument.makeCollectionTimestamp()}"
+        butler.registry.registerCollection(output_run, lsst.daf.butler.CollectionType.RUN)
+        butler.registry.registerCollection(output, lsst.daf.butler.CollectionType.CHAINED)
+        butler.registry.setCollectionChain(output, [output_run])
+        self.butler = lsst.daf.butler.Butler(butler=butler, collections=[output], run=output_run)
+
+        self.butler.registry.registerDatasetType(
+            lsst.daf.butler.DatasetType(
+                "input",
+                dimensions=self.butler.registry.dimensions.empty,
+                storageClass="StructuredDataDict",
+            )
+        )
+        self.butler.put({"zero": 0}, "input")
+
+    def test_init_badinput(self):
+        butler = lsst.daf.butler.Butler(butler=self.butler, collections=[], run="foo")
+
+        with self.assertRaises(ValueError):
+            SeparablePipelineExecutor(butler)
+
+    def test_init_badoutput(self):
+        butler = lsst.daf.butler.Butler(butler=self.butler, collections=["foo"])
+
+        with self.assertRaises(ValueError):
+            SeparablePipelineExecutor(butler)
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
This PR adds a new executor, `SeparablePipelineExecutor`, to `ctrl_mpexec`. This executor adopts elements of, and can be considered intermediate between, `SimplePipelineExecutor` and `CmdLineFwk`. The test suite is based on that for `SimplePipelineExecutor`, and can't test some capabilities (e.g., restricting input data IDs); more tests will be added later.