### PR TITLE
DM-38669: Add workaround for Python threading bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ git+https://github.com/lsst/daf_butler@main#egg=lsst-daf-butler
 git+https://github.com/lsst/utils@main#egg=lsst-utils
 git+https://github.com/lsst/pipe_base@main#egg=lsst-pipe-base
 git+https://github.com/lsst/pex_config@main#egg=lsst-pex-config
-sqlalchemy <2.0
+sqlalchemy


### PR DESCRIPTION
The bug causes occasional issues with multi-process pipeline executions with pytest using concurrent running. This is a known issue (https://github.com/python/cpython/issues/102512) which will eventually be fixed in Python, at that time the patch should become no-op and can be removed.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
