### PR TITLE
DM-38780: Add new CLI sub-command to update output run in a graph 

### DIFF
--- a/doc/changes/DM-38780.feature.md
+++ b/doc/changes/DM-38780.feature.md
@@ -1,0 +1,1 @@
+`pipetask` CLI adds new command `update-graph-run`. It updates existing quantum graph with new output run name and re-generates output dataset IDs.

--- a/python/lsst/ctrl/mpexec/cli/cmd/__init__.py
+++ b/python/lsst/ctrl/mpexec/cli/cmd/__init__.py
@@ -19,7 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-__all__ = ["build", "cleanup", "pre_exec_init_qbb", "purge", "qgraph", "run", "run_qbb"]
+__all__ = ["build", "cleanup", "pre_exec_init_qbb", "purge", "qgraph", "run", "run_qbb", "update_graph_run"]
 
 
-from .commands import build, cleanup, pre_exec_init_qbb, purge, qgraph, run, run_qbb
+from .commands import build, cleanup, pre_exec_init_qbb, purge, qgraph, run, run_qbb, update_graph_run

--- a/python/lsst/ctrl/mpexec/cli/cmd/commands.py
+++ b/python/lsst/ctrl/mpexec/cli/cmd/commands.py
@@ -317,3 +317,28 @@ def run_qbb(repo: str, qgraph: str, **kwargs: Any) -> None:
     finally:
         if coverage:
             _stop_coverage(cov)
+
+
+@click.command(cls=PipetaskCommand)
+@ctrlMpExecOpts.qgraph_argument()
+@ctrlMpExecOpts.run_argument()
+@ctrlMpExecOpts.output_qgraph_argument()
+@ctrlMpExecOpts.metadata_run_key_option()
+@ctrlMpExecOpts.update_graph_id_option()
+def update_graph_run(
+    qgraph: str,
+    run: str,
+    output_qgraph: str,
+    metadata_run_key: str,
+    update_graph_id: bool,
+) -> None:
+    """Update existing quantum graph with new output run name and re-generate
+    output dataset IDs.
+
+    QGRAPH is the URL to a serialized Quantum Graph file.
+
+    RUN is the new RUN collection name for output graph.
+
+    OUTPUT_QGRAPH is the URL to store the updated Quantum Graph.
+    """
+    script.update_graph_run(qgraph, run, output_qgraph, metadata_run_key, update_graph_id)

--- a/python/lsst/ctrl/mpexec/cli/opt/arguments.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/arguments.py
@@ -25,3 +25,7 @@ from lsst.daf.butler.cli.utils import MWArgumentDecorator
 collection_argument = MWArgumentDecorator("collection")
 
 qgraph_argument = MWArgumentDecorator("qgraph")
+
+run_argument = MWArgumentDecorator("run")
+
+output_qgraph_argument = MWArgumentDecorator("output-qgraph")

--- a/python/lsst/ctrl/mpexec/cli/opt/options.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/options.py
@@ -481,3 +481,19 @@ config_search_path_option = MWOptionDecorator(
     metavar="PATH",
     multiple=True,
 )
+
+update_graph_id_option = MWOptionDecorator(
+    "--update-graph-id",
+    help=unwrap("Update graph ID with new unique value."),
+    is_flag=True,
+)
+
+metadata_run_key_option = MWOptionDecorator(
+    "--metadata-run-key",
+    help=(
+        "Quantum graph metadata key for the name of the output run. "
+        "Empty string disables update of the metadata. "
+        "Default value: output_run."
+    ),
+    default="output_run",
+)

--- a/python/lsst/ctrl/mpexec/cli/script/__init__.py
+++ b/python/lsst/ctrl/mpexec/cli/script/__init__.py
@@ -27,3 +27,4 @@ from .purge import PurgeResult, purge
 from .qgraph import qgraph
 from .run import run
 from .run_qbb import run_qbb
+from .update_graph_run import update_graph_run

--- a/python/lsst/ctrl/mpexec/cli/script/update_graph_run.py
+++ b/python/lsst/ctrl/mpexec/cli/script/update_graph_run.py
@@ -1,0 +1,50 @@
+# This file is part of ctrl_mpexec.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lsst.pipe.base import QuantumGraph
+from lsst.resources import ResourcePathExpression
+
+
+def update_graph_run(
+    input_graph: ResourcePathExpression,
+    run: str,
+    output_graph: ResourcePathExpression,
+    metadata_run_key: str,
+    update_graph_id: bool,
+) -> None:
+    """Update quantum graph with new output run name and dataset IDs and save
+    updated graph to a file.
+
+    Parameters
+    ----------
+    input_graph : `~lsst.resources.ResourcePathExpression`
+        Location of a file with existing quantum graph.
+    run : `str`
+        Collection name, if collection exists it must be of ``RUN`` type.
+    output_graph : `~lsst.resources.ResourcePathExpression`
+        Location to store updated quantum graph.
+    update_graph_id : `bool`
+        If `True` then also update graph ID with a new unique value.
+    """
+    qgraph = QuantumGraph.loadUri(input_graph)
+    key = metadata_run_key if metadata_run_key else None
+    qgraph.updateRun(run, metadata_key=key, update_graph_id=update_graph_id)
+    qgraph.saveUri(output_graph)

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -582,6 +582,7 @@ class CmdLineFwk:
                 "user": getpass.getuser(),
                 "time": f"{datetime.datetime.now()}",
             }
+            assert run is not None, "Butler output run collection must be defined"
             qgraph = graphBuilder.makeGraph(
                 pipeline,
                 collections,
@@ -589,7 +590,6 @@ class CmdLineFwk:
                 args.data_query,
                 metadata=metadata,
                 datasetQueryConstraint=args.dataset_query_constraint,
-                resolveRefs=True,
             )
             if args.show_qgraph_header:
                 qgraph.buildAndPrintHeader()

--- a/python/lsst/ctrl/mpexec/separablePipelineExecutor.py
+++ b/python/lsst/ctrl/mpexec/separablePipelineExecutor.py
@@ -56,11 +56,10 @@ class _GraphBuilderLike(Protocol):
         self,
         pipeline: lsst.pipe.base.Pipeline | Iterable[lsst.pipe.base.pipeline.TaskDef],
         collections: Any,
-        run: str | None,
+        run: str,
         userQuery: str | None,
         datasetQueryConstraint: _dqc.DatasetQueryConstraintVariant = _dqc._ALL,
         metadata: Mapping[str, Any] | None = None,
-        resolveRefs: bool = False,
         bind: Mapping[str, Any] | None = None,
     ) -> lsst.pipe.base.QuantumGraph:
         pass
@@ -210,13 +209,13 @@ class SeparablePipelineExecutor:
             "user": getpass.getuser(),
             "time": str(datetime.datetime.now()),
         }
+        assert self._butler.run is not None, "Butler output run collection must be defined"
         graph = builder.makeGraph(
             pipeline,
             self._butler.collections,
             self._butler.run,
             userQuery=where,
             metadata=metadata,
-            resolveRefs=True,
         )
         _LOG.info(
             "QuantumGraph contains %d quanta for %d tasks, graph ID: %r",

--- a/python/lsst/ctrl/mpexec/simple_pipeline_executor.py
+++ b/python/lsst/ctrl/mpexec/simple_pipeline_executor.py
@@ -236,6 +236,7 @@ class SimplePipelineExecutor:
         else:
             pipeline = list(pipeline)
         graph_builder = GraphBuilder(butler.registry)
+        assert butler.run is not None, "Butler output run collection must be defined"
         quantum_graph = graph_builder.makeGraph(
             pipeline, collections=butler.collections, run=butler.run, userQuery=where, bind=bind
         )

--- a/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
+++ b/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
@@ -96,7 +96,7 @@ class SingleQuantumExecutor(QuantumExecutor):
     clobberOutputs : `bool`, optional
         If `True`, then existing qauntum outputs in output run collection will
         be removed prior to executing a quantum.  If ``skipExistingIn`` is
-        defined, only patial outputs from failed quanta will be overwritten
+        defined, only partial outputs from failed quanta will be overwritten
         (see notes). Only used when ``butler`` is not `None`.
     enableLsstDebug : `bool`, optional
         Enable debugging with ``lsstDebug`` facility for a task.
@@ -117,10 +117,10 @@ class SingleQuantumExecutor(QuantumExecutor):
     Notes
     -----
     There is a non-trivial interaction between ``skipExistingIn`` and
-    ``clobberOutputs`` areguments. Here is how they wortk together:
+    ``clobberOutputs`` areguments. Here is how they work together:
 
     - If ``skipExistingIn`` is specified (or `None`) then those collections
-      are searched for quantum output datasets, If all outputs are found then
+      are searched for quantum output datasets. If all outputs are found, then
       quantum is not executed and `run` completes successfully.
     - Otherwise if ``clobberOutputs`` is `True` then butler output RUN
       collection is checked for existing quantum outputs. If full or partial

--- a/tests/test_cliCmdUpdateGraphRun.py
+++ b/tests/test_cliCmdUpdateGraphRun.py
@@ -1,0 +1,108 @@
+# This file is part of ctrl_mpexec.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for ctrl_mpexec CLI update-graph-run subcommand."""
+
+import os
+import unittest
+
+from lsst.ctrl.mpexec.cli.pipetask import cli as pipetask_cli
+from lsst.daf.butler.cli.utils import LogCliRunner, clickResultMsg
+from lsst.daf.butler.tests.utils import makeTestTempDir, removeTestTempDir
+from lsst.pipe.base import QuantumGraph
+from lsst.pipe.base.tests.simpleQGraph import makeSimpleQGraph
+from lsst.pipe.base.tests.util import check_output_run
+
+TESTDIR = os.path.abspath(os.path.dirname(__file__))
+
+
+class UpdateGraphRunTest(unittest.TestCase):
+    """Test executing "pipetask update-graph-run" commands."""
+
+    instrument = "lsst.pipe.base.tests.simpleQGraph.SimpleInstrument"
+
+    def setUp(self) -> None:
+        self.runner = LogCliRunner()
+        self.root = makeTestTempDir(TESTDIR)
+
+    def tearDown(self) -> None:
+        removeTestTempDir(self.root)
+
+    def test_update(self):
+        """Test for updating output run in a graph."""
+
+        nQuanta = 3
+        metadata = {"output_run": "run"}
+        _, qgraph = makeSimpleQGraph(
+            nQuanta,
+            run="run",
+            root=self.root,
+            instrument=self.instrument,
+            metadata=metadata,
+            resolveRefs=True,
+        )
+        self.assertEqual(check_output_run(qgraph, "run"), [])
+
+        old_path = os.path.join(self.root, "graph.qgraph")
+        qgraph.saveUri(old_path)
+
+        new_path = os.path.join(self.root, "graph-updated.qgraph")
+        result = self.runner.invoke(
+            pipetask_cli,
+            ["update-graph-run", old_path, "new-run", new_path],
+            input="no",
+        )
+        self.assertEqual(result.exit_code, 0, clickResultMsg(result))
+
+        updated_graph = QuantumGraph.loadUri(new_path)
+        self.assertEqual(check_output_run(updated_graph, "new-run"), [])
+        assert updated_graph.metadata is not None
+        self.assertEqual(updated_graph.metadata["output_run"], "new-run")
+        self.assertEqual(updated_graph.graphID, qgraph.graphID)
+
+        # Check that we can turn off metadata updates.
+        result = self.runner.invoke(
+            pipetask_cli,
+            ["update-graph-run", "--metadata-run-key=''", old_path, "new-run2", new_path],
+            input="no",
+        )
+        self.assertEqual(result.exit_code, 0, clickResultMsg(result))
+
+        updated_graph = QuantumGraph.loadUri(new_path)
+        self.assertEqual(check_output_run(updated_graph, "new-run2"), [])
+        assert updated_graph.metadata is not None
+        self.assertEqual(updated_graph.metadata["output_run"], "run")
+
+        # Now check that we can make new graph ID.
+        result = self.runner.invoke(
+            pipetask_cli,
+            ["update-graph-run", "--update-graph-id", old_path, "new-run3", new_path],
+            input="no",
+        )
+        self.assertEqual(result.exit_code, 0, clickResultMsg(result))
+
+        updated_graph = QuantumGraph.loadUri(new_path)
+        self.assertEqual(check_output_run(updated_graph, "new-run3"), [])
+        self.assertNotEqual(updated_graph.graphID, qgraph.graphID)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cliCmdUpdateGraphRun.py
+++ b/tests/test_cliCmdUpdateGraphRun.py
@@ -57,7 +57,6 @@ class UpdateGraphRunTest(unittest.TestCase):
             root=self.root,
             instrument=self.instrument,
             metadata=metadata,
-            resolveRefs=True,
         )
         self.assertEqual(check_output_run(qgraph, "run"), [])
 

--- a/tests/test_separablePipelineExecutor.py
+++ b/tests/test_separablePipelineExecutor.py
@@ -342,10 +342,10 @@ class SeparablePipelineExecutorTests(lsst.utils.tests.TestCase):
         self.butler.put(TaskMetadata(), "a_metadata")
 
         graph = executor.make_quantum_graph(pipeline)
-        self.assertFalse(graph.isConnected)  # Both tasks run, but can use old values for b
+        self.assertTrue(graph.isConnected)
         self.assertEqual(len(graph), 2)
-        self.assertEqual({q.taskDef.label for q in graph.inputQuanta}, {"a", "b"})
-        self.assertEqual({q.taskDef.label for q in graph.outputQuanta}, {"a", "b"})
+        self.assertEqual({q.taskDef.label for q in graph.inputQuanta}, {"a"})
+        self.assertEqual({q.taskDef.label for q in graph.outputQuanta}, {"b"})
 
     def test_make_quantum_graph_nowhere_skipnone_clobber(self):
         executor = SeparablePipelineExecutor(
@@ -394,10 +394,10 @@ class SeparablePipelineExecutorTests(lsst.utils.tests.TestCase):
         self.butler.put({"zero": 0}, "intermediate")
 
         graph = executor.make_quantum_graph(pipeline)
-        self.assertFalse(graph.isConnected)  # Both tasks run, but can use old values for b
+        self.assertTrue(graph.isConnected)
         self.assertEqual(len(graph), 2)
-        self.assertEqual({q.taskDef.label for q in graph.inputQuanta}, {"a", "b"})
-        self.assertEqual({q.taskDef.label for q in graph.outputQuanta}, {"a", "b"})
+        self.assertEqual({q.taskDef.label for q in graph.inputQuanta}, {"a"})
+        self.assertEqual({q.taskDef.label for q in graph.outputQuanta}, {"b"})
 
     def test_make_quantum_graph_noinput(self):
         executor = SeparablePipelineExecutor(self.butler)
@@ -520,7 +520,6 @@ class SeparablePipelineExecutorTests(lsst.utils.tests.TestCase):
         self.assertEqual(self.butler.get("intermediate"), {"zero": 0, "one": 1})
         self.assertEqual(self.butler.get("output"), {"zero": 0, "one": 1, "two": 2})
 
-    @unittest.skip("Will not work until DM-38601 is fixed.")
     def test_run_pipeline_noskip_clobber_unconnected(self):
         executor = SeparablePipelineExecutor(self.butler, skip_existing_in=None, clobber_output=True)
         pipeline = Pipeline.fromFile(self.pipeline_file)
@@ -586,7 +585,6 @@ class SeparablePipelineExecutorTests(lsst.utils.tests.TestCase):
         self.butler.registry.refresh()
         self.assertEqual(self.butler.get("output"), {"zero": 0, "two": 2})
 
-    @unittest.skip("Bad behavior with unconnected graph; Middleware will investigate after DM-33027")
     def test_run_pipeline_skippartial_clobber_unconnected(self):
         executor = SeparablePipelineExecutor(
             self.butler,


### PR DESCRIPTION
The new command takes existing serialized quantum graph file, updates
output run and dataset IDs for all output datasets and writes updated
graph to a new file.

Fixes clobbering logic in SingleQuantumExecutor.

Few additional small updates related to changes in graph builder interface.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
