### PR TITLE
DM-38779: Try to fix output run inconsistency

### DIFF
--- a/doc/changes/DM-38779.misc.rst
+++ b/doc/changes/DM-38779.misc.rst
@@ -1,0 +1,5 @@
+* ``SingleQuantumExecutor`` has been modified such that it no longer unresolves ``DatasetRef`` when putting the non-``PipelineTask`` datasets (such as packages and configs).
+  This has been done so that the refs in the quantum graph are preserved when they are written to a normal Butler.
+* Fixed a race condition when ``pipetask run`` creates the graph with a timestamped output run and then executes it.
+  Previously the graph creation and run execution phases calculated their own timestamped output run and it would be possible for the execution output run to be one second later than the graph run.
+  Previously this did not matter (the graph run was being ignored) but with the change to always use the ``DatasetRef`` from the graph it becomes critical that they match.

--- a/python/lsst/ctrl/mpexec/cli/script/run.py
+++ b/python/lsst/ctrl/mpexec/cli/script/run.py
@@ -190,4 +190,10 @@ def run(  # type: ignore
 
     f = CmdLineFwk()
     taskFactory = TaskFactory()
+
+    # If we have no output run specified, use the one from the graph rather
+    # than letting a new timestamped run be created.
+    if not args.output_run and qgraphObj.metadata and (output_run := qgraphObj.metadata.get("output_run")):
+        args.output_run = output_run
+
     f.runPipeline(qgraphObj, taskFactory, args)

--- a/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
+++ b/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
@@ -620,13 +620,14 @@ class SingleQuantumExecutor(QuantumExecutor):
                     " and execution"
                 ) from exc
             if self.butler is not None:
-                # Dataset ref can already be resolved, for non-QBB executor we
-                # have to ignore that because may be overriding run
-                # collection.
+                # Dataset ref will already be resolved. We are now required
+                # to respect the output run of the ref so can not unresolve.
                 if ref.id is not None:
-                    with warnings.catch_warnings():
-                        warnings.simplefilter("ignore", category=UnresolvedRefWarning)
-                        ref = ref.unresolved()
+                    if ref.run != self.butler.run:  # This test allows for clearer error message.
+                        raise RuntimeError(
+                            f"Inconsistency in RUN when putting resolved ref. "
+                            f"Ref has run {ref.run!r} but butler is putting it into {self.butler.run!r}"
+                        )
                 self.butler.put(metadata, ref)
             else:
                 limited_butler.put(metadata, ref)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ networkx
 git+https://github.com/lsst/resources@main#egg=lsst-resources
 git+https://github.com/lsst/daf_butler@main#egg=lsst-daf-butler
 git+https://github.com/lsst/utils@main#egg=lsst-utils
-git+https://github.com/lsst/pipe_base@main#egg=lsst-pipe-base
+git+https://github.com/lsst/pipe_base@tickets/DM-38779#egg=lsst-pipe-base
 git+https://github.com/lsst/pex_config@main#egg=lsst-pex-config
 sqlalchemy

--- a/tests/test_cmdLineFwk.py
+++ b/tests/test_cmdLineFwk.py
@@ -490,6 +490,11 @@ class CmdLineFwkTestCaseWithButler(unittest.TestCase):
         self.assertEqual(len(qgraph.taskGraph), self.nQuanta)
         self.assertEqual(len(qgraph), self.nQuanta)
 
+        # Ensure that the output run used in the graph is also used in
+        # the pipeline execution. It is possible for makeGraph and runPipeline
+        # to calculate time-stamped runs across a second boundary.
+        args.output_run = qgraph.metadata["output_run"]
+
         # run whole thing
         fwk.runPipeline(qgraph, taskFactory, args)
         self.assertEqual(taskFactory.countExec, self.nQuanta)
@@ -552,6 +557,11 @@ class CmdLineFwkTestCaseWithButler(unittest.TestCase):
         # executing one quantum is skipped.
         self.assertEqual(len(qgraph), self.nQuanta)
 
+        # Ensure that the output run used in the graph is also used in
+        # the pipeline execution. It is possible for makeGraph and runPipeline
+        # to calculate time-stamped runs across a second boundary.
+        args.output_run = qgraph.metadata["output_run"]
+
         # run whole thing
         fwk.runPipeline(qgraph, taskFactory, args)
         self.assertEqual(taskFactory.countExec, self.nQuanta)
@@ -590,6 +600,11 @@ class CmdLineFwkTestCaseWithButler(unittest.TestCase):
         qgraph = fwk.makeGraph(self.pipeline, args)
         self.assertEqual(len(qgraph.taskGraph), self.nQuanta)
         self.assertEqual(len(qgraph), self.nQuanta - 1)
+
+        # Ensure that the output run used in the graph is also used in
+        # the pipeline execution. It is possible for makeGraph and runPipeline
+        # to calculate time-stamped runs across a second boundary.
+        args.output_run = qgraph.metadata["output_run"]
 
         # run whole thing
         fwk.runPipeline(qgraph, taskFactory, args)
@@ -655,6 +670,11 @@ class CmdLineFwkTestCaseWithButler(unittest.TestCase):
         qgraph = fwk.makeGraph(self.pipeline, args)
         self.assertEqual(len(qgraph), self.nQuanta)
 
+        # Ensure that the output run used in the graph is also used in
+        # the pipeline execution. It is possible for makeGraph and runPipeline
+        # to calculate time-stamped runs across a second boundary.
+        args.output_run = qgraph.metadata["output_run"]
+
         # run first three quanta
         with self.assertRaises(MPGraphExecutorError):
             fwk.runPipeline(qgraph, taskFactory, args)
@@ -673,6 +693,11 @@ class CmdLineFwkTestCaseWithButler(unittest.TestCase):
         )
         self.assertIsNotNone(ref2)
         butler.pruneDatasets([ref1, ref2], disassociate=True, unstore=True, purge=True)
+
+        # Ensure that the output run used in the graph is also used in
+        # the pipeline execution. It is possible for makeGraph and runPipeline
+        # to calculate time-stamped runs across a second boundary.
+        args.output_run = qgraph.metadata["output_run"]
 
         taskFactory.stopAt = -1
         args.skip_existing_in = (args.output,)
@@ -696,6 +721,11 @@ class CmdLineFwkTestCaseWithButler(unittest.TestCase):
 
         # should have one task and number of quanta
         self.assertEqual(len(qgraph), self.nQuanta)
+
+        # Ensure that the output run used in the graph is also used in
+        # the pipeline execution. It is possible for makeGraph and runPipeline
+        # to calculate time-stamped runs across a second boundary.
+        args.output_run = qgraph.metadata["output_run"]
 
         # run first three quanta
         with self.assertRaises(MPGraphExecutorError):
@@ -865,6 +895,11 @@ class CmdLineFwkTestCaseWithButler(unittest.TestCase):
         self.assertEqual(len(qgraph.taskGraph), self.nQuanta)
         self.assertEqual(len(qgraph), self.nQuanta)
 
+        # Ensure that the output run used in the graph is also used in
+        # the pipeline execution. It is possible for makeGraph and runPipeline
+        # to calculate time-stamped runs across a second boundary.
+        args.output_run = qgraph.metadata["output_run"]
+
         # run whole thing
         fwk.runPipeline(qgraph, taskFactory, args)
         # None of the actual tasks is executed
@@ -897,6 +932,11 @@ class CmdLineFwkTestCaseWithButler(unittest.TestCase):
         qgraph = fwk.makeGraph(self.pipeline, args)
         self.assertEqual(len(qgraph.taskGraph), self.nQuanta)
         self.assertEqual(len(qgraph), self.nQuanta)
+
+        # Ensure that the output run used in the graph is also used in
+        # the pipeline execution. It is possible for makeGraph and runPipeline
+        # to calculate time-stamped runs across a second boundary.
+        args.output_run = qgraph.metadata["output_run"]
 
         with self.assertRaises(MPGraphExecutorError) as cm:
             fwk.runPipeline(qgraph, taskFactory, args)


### PR DESCRIPTION
This seems to be a real problem that is present in `pipetask run` itself but which we mask because the current code unresolves refs on put. The problem is that:

* makeGraph reads the supplied args, determines a time-stamped output run, and uses that to build the graph.
* runPipeline takes the graph and the args but uses the args to make a time-stamped output run.
* If the second has ticked over the output run is now different than the one used for the graph.
* singleQuantumExecutor runs and when Butler.put happens it unresolves the refs in the graph so that the timestamped RUN in the ref gets cleared and instead the butler's default RUN is used (and new UUID is issued).

I was expecting the unresolving to go away in #233 but we decided to leave that in place for now.

Fixing the tests is relatively easy. I will see if I can do a similar fix for `pipetask run` itself.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
