### PR TITLE
DM-39122: Remove UnresolvedRefWarning filters

### DIFF
--- a/doc/changes/DM-39122.doc.md
+++ b/doc/changes/DM-39122.doc.md
@@ -1,0 +1,1 @@
+Command line help for `pipetask run` is updated to reflect its correct clobbering behavior.

--- a/python/lsst/ctrl/mpexec/cli/opt/options.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/options.py
@@ -63,11 +63,11 @@ pdb_option = MWOptionDecorator(
 
 extend_run_option = MWOptionDecorator(
     "--extend-run",
-    help=unwrap(
-        """Instead of creating a new RUN collection, insert datasets
-                                                  into either the one given by --output-run (if provided) or
-                                                  the first child collection of --output (which must be of
-                                                  type RUN). This also enables --skip-existing option."""
+    help=(
+        "Instead of creating a new RUN collection, insert datasets into either the one given by "
+        "--output-run (if provided) or the first child collection of --output (which must be of type RUN). "
+        "This also enables --skip-existing option when building a graph. "
+        "When executing a graph this option skips quanta with all existing outputs."
     ),
     is_flag=True,
 )
@@ -344,12 +344,10 @@ skip_existing_option = MWOptionDecorator(
 
 clobber_outputs_option = MWOptionDecorator(
     "--clobber-outputs",
-    help=unwrap(
-        """Remove outputs from previous execution of the same
-                                                       quantum before new execution.  If --skip-existing
-                                                       is also passed, then only failed quanta will be
-                                                       clobbered. Requires the 'run' command's --extend-run
-                                                       flag to be set."""
+    help=(
+        "Remove outputs of failed quanta from the output run when they would block the execution of new "
+        "quanta with the same data ID (or assume that this will be done, if just building a QuantumGraph).  "
+        "Does nothing if --extend-run is not passed."
     ),
     is_flag=True,
 )

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -690,9 +690,12 @@ class CmdLineFwk:
                     "To update graph metadata run `pipetask update-graph-run` command."
                 )
 
-        # make sure that --extend-run always enables --skip-existing
+        # Make sure that --extend-run always enables --skip-existing,
+        # clobbering should be disabled if --extend-run is not specified.
         if args.extend_run:
             args.skip_existing = True
+        else:
+            args.clobber_outputs = False
 
         if not args.enable_implicit_threading:
             disable_implicit_threading()

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -679,6 +679,17 @@ class CmdLineFwk:
             Data Butler instance, if not defined then new instance is made
             using command line options.
         """
+        # Check that output run defined on command line is consistent with
+        # quantum graph.
+        if args.output_run and graph.metadata:
+            graph_output_run = graph.metadata.get("output_run", args.output_run)
+            if graph_output_run != args.output_run:
+                raise ValueError(
+                    f"Output run defined on command line ({args.output_run}) has to be "
+                    f"identical to graph metadata ({graph_output_run}). "
+                    "To update graph metadata run `pipetask update-graph-run` command."
+                )
+
         # make sure that --extend-run always enables --skip-existing
         if args.extend_run:
             args.skip_existing = True

--- a/python/lsst/ctrl/mpexec/mock_task.py
+++ b/python/lsst/ctrl/mpexec/mock_task.py
@@ -20,10 +20,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-import warnings
 from typing import Any, List, Optional, Union
 
-from lsst.daf.butler import Butler, DatasetRef, Quantum, UnresolvedRefWarning
+from lsst.daf.butler import Butler, DatasetRef, Quantum
 from lsst.pex.config import Field
 from lsst.pipe.base import (
     ButlerQuantumContext,
@@ -108,16 +107,12 @@ class MockButlerQuantumContext(ButlerQuantumContext):
         # docstring is inherited from the base class
 
         mockDatasetType = self.registry.getDatasetType(self.mockDatasetTypeName(ref.datasetType.name))
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=UnresolvedRefWarning)
-            mockRef = DatasetRef(mockDatasetType, ref.dataId)
+        mockRef = DatasetRef(mockDatasetType, ref.dataId, run=ref.run)
         value.setdefault("ref", {}).update(datasetType=mockDatasetType.name)
         self.butler.put(value, mockRef)
 
-        # also "store" non-mock refs, make sure it is not resolved.
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=UnresolvedRefWarning)
-            self.registry._importDatasets([ref.unresolved()])
+        # Also "store" non-mock refs.
+        self.registry._importDatasets([ref])
 
     def _checkMembership(self, ref: Union[List[DatasetRef], DatasetRef], inout: set) -> None:
         # docstring is inherited from the base class

--- a/python/lsst/ctrl/mpexec/mpGraphExecutor.py
+++ b/python/lsst/ctrl/mpexec/mpGraphExecutor.py
@@ -32,12 +32,10 @@ import signal
 import sys
 import threading
 import time
-import warnings
 from collections.abc import Iterable
 from enum import Enum
 from typing import Literal, Optional
 
-from lsst.daf.butler import UnresolvedRefWarning
 from lsst.daf.butler.cli.cliLog import CliLog
 from lsst.pipe.base import InvalidQuantumError, TaskDef
 from lsst.pipe.base.graph.graph import QuantumGraph, QuantumNode
@@ -158,11 +156,7 @@ class _Job:
             # re-initialize logging
             CliLog.replayConfigState(logConfigState)
 
-        with warnings.catch_warnings():
-            # Loading the pickle file can trigger unresolved ref warnings
-            # so we must hide them.
-            warnings.simplefilter("ignore", category=UnresolvedRefWarning)
-            quantum = pickle.loads(quantum_pickle)
+        quantum = pickle.loads(quantum_pickle)
         try:
             quantumExecutor.execute(taskDef, quantum)
         finally:

--- a/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
+++ b/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
@@ -31,9 +31,18 @@ import time
 from collections import defaultdict
 from collections.abc import Callable
 from itertools import chain
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
-from lsst.daf.butler import Butler, DatasetRef, DatasetType, LimitedButler, NamedKeyDict, Quantum
+from lsst.daf.butler import (
+    Butler,
+    CollectionType,
+    DatasetRef,
+    DatasetType,
+    LimitedButler,
+    NamedKeyDict,
+    Quantum,
+)
+from lsst.daf.butler.registry.wildcards import CollectionWildcard
 from lsst.pipe.base import (
     AdjustQuantumHelper,
     ButlerQuantumContext,
@@ -78,17 +87,18 @@ class SingleQuantumExecutor(QuantumExecutor):
         instead.
     taskFactory : `~lsst.pipe.base.TaskFactory`
         Instance of a task factory.
-    skipExistingIn : `list` [ `str` ], optional
-        Accepts list of collections, if all Quantum outputs already exist in
-        the specified list of collections then that Quantum will not be rerun.
-        If `None` then butler output RUN collection is searched for existing
-        datasets. If empty list then there no check for existing outputs (which
-        could result in conflicts when datasets are stored).
+    skipExistingIn
+        Expressions representing the collections to search for existing
+        output datasets. See :ref:`daf_butler_ordered_collection_searches`
+        for allowed types. This class only checks for the presence of butler
+        output run in the list of collections. If the output run is present
+        in the list then the quanta whose complete outputs exist in the output
+        run will be skipped. `None` or empty string/sequence disables skipping.
     clobberOutputs : `bool`, optional
-        If `True`, then existing qauntum outputs in output run collection will
-        be removed prior to executing a quantum.  If ``skipExistingIn`` is
-        defined, only partial outputs from failed quanta will be overwritten
-        (see notes). Only used when ``butler`` is not `None`.
+        If `True`, then outputs from a quantum that exist in output run
+        collection will be removed prior to executing a quantum. If
+        ``skipExistingIn`` contains output run, then only partial outputs from
+        a quantum will be removed. Only used when ``butler`` is not `None`.
     enableLsstDebug : `bool`, optional
         Enable debugging with ``lsstDebug`` facility for a task.
     exitOnKnownError : `bool`, optional
@@ -104,32 +114,13 @@ class SingleQuantumExecutor(QuantumExecutor):
         A method that creates a `~lsst.daf.butler.LimitedButler` instance
         for a given Quantum. This parameter must be defined if ``butler`` is
         `None`. If ``butler`` is not `None` then this parameter is ignored.
-
-    Notes
-    -----
-    There is a non-trivial interaction between ``skipExistingIn`` and
-    ``clobberOutputs`` areguments. Here is how they work together:
-
-    - If ``skipExistingIn`` is specified (or `None`) then those collections
-      are searched for quantum output datasets. If all outputs are found, then
-      quantum is not executed and `run` completes successfully.
-    - Otherwise if ``clobberOutputs`` is `True` then butler output RUN
-      collection is checked for existing quantum outputs. If full or partial
-      outputs are found, they are are pruned and quantum is executed.
-    - Otherwise if ``clobberOutputs`` is `False` then butler output RUN
-      collection is checked for existing quantum outputs. If any output
-      dataset is found an exception is raised.
-
-    This leaves the case when partial quantum outputs may be found in
-    ``skipExistingIn`` but that list does not include butler RUN collection.
-    Those partial outputs are not prunned.
     """
 
     def __init__(
         self,
         butler: Butler | None,
         taskFactory: TaskFactory,
-        skipExistingIn: list[str] | None = None,
+        skipExistingIn: Any = None,
         clobberOutputs: bool = False,
         enableLsstDebug: bool = False,
         exitOnKnownError: bool = False,
@@ -139,7 +130,6 @@ class SingleQuantumExecutor(QuantumExecutor):
     ):
         self.butler = butler
         self.taskFactory = taskFactory
-        self.skipExistingIn = skipExistingIn
         self.enableLsstDebug = enableLsstDebug
         self.clobberOutputs = clobberOutputs
         self.exitOnKnownError = exitOnKnownError
@@ -151,6 +141,21 @@ class SingleQuantumExecutor(QuantumExecutor):
         if self.butler is None:
             assert not self.mock, "Mock execution only possible with full butler"
             assert limited_butler_factory is not None, "limited_butler_factory is needed when butler is None"
+
+        # Find whether output run is in skipExistingIn.
+        # TODO: This duplicates logic in GraphBuilder, would be nice to have
+        # better abstraction for this some day.
+        self.skipExisting = False
+        if self.butler is not None and skipExistingIn:
+            skip_collections_wildcard = CollectionWildcard.from_expression(skipExistingIn)
+            # As optimization check in the explicit list of names first
+            self.skipExisting = self.butler.run in skip_collections_wildcard.strings
+            if not self.skipExisting:
+                # need to flatten it and check again
+                self.skipExisting = self.butler.run in self.butler.registry.queryCollections(
+                    skipExistingIn,
+                    collectionTypes=CollectionType.RUN,
+                )
 
     def execute(self, taskDef: TaskDef, quantum: Quantum) -> Quantum:
         # Docstring inherited from QuantumExecutor.execute
@@ -310,7 +315,7 @@ class SingleQuantumExecutor(QuantumExecutor):
         Returns
         -------
         exist : `bool`
-            `True` if ``self.skipExistingIn`` is defined, and a previous
+            `True` if ``self.skipExisting`` is defined, and a previous
             execution of this quanta appears to have completed successfully
             (either because metadata was written or all datasets were written).
             `False` otherwise.
@@ -320,7 +325,11 @@ class SingleQuantumExecutor(QuantumExecutor):
         RuntimeError
             Raised if some outputs exist and some not.
         """
-        if self.skipExistingIn and taskDef.metadataDatasetName is not None:
+        if not self.butler:
+            # Skip/prune logic only works for full butler.
+            return False
+
+        if self.skipExisting and taskDef.metadataDatasetName is not None:
             # Metadata output exists; this is sufficient to assume the previous
             # run was successful and should be skipped.
             [metadata_ref] = quantum.outputs[taskDef.metadataDatasetName]
@@ -328,65 +337,29 @@ class SingleQuantumExecutor(QuantumExecutor):
                 if limited_butler.datastore.exists(metadata_ref):
                     return True
 
-        # Previously we always checked for existing outputs in `butler.run`,
-        # now logic gets more complicated as we only want to skip quantum
-        # whose outputs exist in `self.skipExistingIn` but pruning should only
-        # be done for outputs existing in `butler.run`.
-
-        def findOutputs(
-            collections: Optional[Union[str, list[str]]]
-        ) -> tuple[list[DatasetRef], list[DatasetRef]]:
-            """Find quantum outputs in specified collections."""
-            existingRefs = []
-            missingRefs = []
-            for datasetRefs in quantum.outputs.values():
-                checkRefs: list[DatasetRef] = []
-                registryRefToQuantumRef: dict[DatasetRef, DatasetRef] = {}
-                for datasetRef in datasetRefs:
-                    if self.butler is not None:
-                        # If running with full butler check registry.
-                        ref = self.butler.registry.findDataset(
-                            datasetRef.datasetType, datasetRef.dataId, collections=collections
-                        )
-                    else:
-                        # In case of QBB assume it must be there.
-                        ref = datasetRef
-                    if ref is None:
-                        missingRefs.append(datasetRef)
-                    else:
-                        checkRefs.append(ref)
-                        registryRefToQuantumRef[ref] = datasetRef
-
-                # More efficient to ask the datastore in bulk for ref
-                # existence rather than one at a time.
-                existence = limited_butler.datastore.mexists(checkRefs)
-                for ref, exists in existence.items():
-                    if exists:
-                        existingRefs.append(ref)
-                    else:
-                        missingRefs.append(registryRefToQuantumRef[ref])
-            return existingRefs, missingRefs
-
-        # If skipExistingIn is None this will search in butler.run.
-        existingRefs, missingRefs = findOutputs(self.skipExistingIn)
-        if self.skipExistingIn:
-            if existingRefs and not missingRefs:
-                # Everything is already there, and we do not clobber complete
-                # outputs if skipExistingIn is specified.
-                return True
-
-        # If we are to re-run quantum then prune datasets that exists in
-        # output run collection, only if `self.clobberOutputs` is set,
-        # that only works when we have full butler.
-        if self.butler is not None:
-            # Look at butler run instead of skipExistingIn collections.
-            existingRefs, missingRefs = findOutputs(self.butler.run)
-            if existingRefs and missingRefs:
+        # Find and prune (partial) outputs if `self.clobberOutputs` is set.
+        ref_dict = self.butler.datastore.mexists(chain.from_iterable(quantum.outputs.values()))
+        existingRefs = [ref for ref, exists in ref_dict.items() if exists]
+        missingRefs = [ref for ref, exists in ref_dict.items() if not exists]
+        if existingRefs:
+            if not missingRefs:
+                # Full outputs exist.
+                if self.skipExisting:
+                    return True
+                elif self.clobberOutputs:
+                    _LOG.info("Removing complete outputs for quantum %s: %s", quantum, existingRefs)
+                    self.butler.pruneDatasets(existingRefs, disassociate=True, unstore=True, purge=True)
+                else:
+                    raise RuntimeError(
+                        f"Complete outputs exists for a quantum {quantum} "
+                        "and neither clobberOutputs nor skipExisting is set: "
+                        f"collection={self.butler.run} existingRefs={existingRefs}"
+                    )
+            else:
+                # Partial outputs from a failed quantum.
                 _LOG.debug(
-                    "Partial outputs exist for task %s dataId=%s collection=%s "
-                    "existingRefs=%s missingRefs=%s",
-                    taskDef,
-                    quantum.dataId,
+                    "Partial outputs exist for quantum %s collection=%s existingRefs=%s missingRefs=%s",
+                    quantum,
                     self.butler.run,
                     existingRefs,
                     missingRefs,
@@ -398,17 +371,12 @@ class SingleQuantumExecutor(QuantumExecutor):
                     return False
                 else:
                     raise RuntimeError(
-                        "Registry inconsistency while checking for existing outputs:"
-                        f" collection={self.butler.run} existingRefs={existingRefs}"
+                        "Registry inconsistency while checking for existing quantum outputs:"
+                        f" quantum={quantum} collection={self.butler.run} existingRefs={existingRefs}"
                         f" missingRefs={missingRefs}"
                     )
-            elif existingRefs and self.clobberOutputs and not self.skipExistingIn:
-                # Clobber complete outputs if skipExistingIn is not specified.
-                _LOG.info("Removing complete outputs for task %s: %s", taskDef, existingRefs)
-                self.butler.pruneDatasets(existingRefs, disassociate=True, unstore=True, purge=True)
-                return False
 
-        # need to re-run
+        # By default always execute.
         return False
 
     def updatedQuantumInputs(


### PR DESCRIPTION
Additionally PreExecInit is cleaned up to always expect resolved refs in quantum graph and use those refs to store initOutputs. `CmdLineFwk` now checks that output runs on command line and in graph are consistent.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
