### PR TITLE
DM-37704: Remove use of unresolved refs.

### DIFF
--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -831,10 +831,10 @@ class CmdLineFwk:
         predicted_outputs: set[DatasetId] = set()
         for taskDef in qgraph.iterTaskGraph():
             if (refs := qgraph.initInputRefs(taskDef)) is not None:
-                predicted_inputs.update(ref.getCheckedId() for ref in refs)
+                predicted_inputs.update(ref.id for ref in refs)
             if (refs := qgraph.initOutputRefs(taskDef)) is not None:
-                predicted_outputs.update(ref.getCheckedId() for ref in refs)
-        predicted_outputs.update(ref.getCheckedId() for ref in qgraph.globalInitOutputRefs())
+                predicted_outputs.update(ref.id for ref in refs)
+        predicted_outputs.update(ref.id for ref in qgraph.globalInitOutputRefs())
         # remove intermediates from inputs
         predicted_inputs -= predicted_outputs
 

--- a/python/lsst/ctrl/mpexec/log_capture.py
+++ b/python/lsst/ctrl/mpexec/log_capture.py
@@ -175,16 +175,7 @@ class LogCapture:
                 " and execution"
             ) from exc
 
-        if self.full_butler is None:
-            # If full butler is not available then we need fully
-            # resolved reference for limited butler.
-            if ref.id is None:
-                raise InvalidQuantumError(
-                    f"Quantum contains unresolved reference for task log output dataset type {dataset_type}."
-                )
-            self.butler.put(log_handler.records, ref)
-        else:
-            self.full_butler.put(log_handler.records, ref)
+        self.butler.put(log_handler.records, ref)
 
     def _ingest_log_records(self, quantum: Quantum, dataset_type: str, filename: str) -> None:
         # If we are logging to an external file we must always try to

--- a/python/lsst/ctrl/mpexec/mock_task.py
+++ b/python/lsst/ctrl/mpexec/mock_task.py
@@ -60,7 +60,7 @@ class MockButlerQuantumContext(ButlerQuantumContext):
     """
 
     def __init__(self, butler: Butler, quantum: Quantum):
-        super().__init__(butler=butler, limited=butler, quantum=quantum)
+        super().__init__(butler, quantum)
         self.butler = butler
         self.registry = butler.registry
 

--- a/python/lsst/ctrl/mpexec/quantumGraphExecutor.py
+++ b/python/lsst/ctrl/mpexec/quantumGraphExecutor.py
@@ -56,12 +56,7 @@ class QuantumExecutor(ABC):
         Returns
         -------
         quantum : `Quantum`
-            The quantum actually executed.  At present this quantum will
-            contain only unresolved `DatasetRef` instances for output datasets,
-            reflecting the state of the quantum just before it was run (but
-            after any adjustments for predicted but now missing inputs).  This
-            may change in the future to include resolved output `DatasetRef`
-            objects.
+            The quantum actually executed.
 
         Notes
         -----

--- a/python/lsst/ctrl/mpexec/simple_pipeline_executor.py
+++ b/python/lsst/ctrl/mpexec/simple_pipeline_executor.py
@@ -260,11 +260,7 @@ class SimplePipelineExecutor:
         Returns
         -------
         quanta : `List` [ `Quantum` ]
-            Executed quanta.  At present, these will contain only unresolved
-            `DatasetRef` instances for output datasets, reflecting the state of
-            the quantum just before it was run (but after any adjustments for
-            predicted but now missing inputs).  This may change in the future
-            to include resolved output `DatasetRef` objects.
+            Executed quanta.
 
         Notes
         -----
@@ -295,12 +291,7 @@ class SimplePipelineExecutor:
         Returns
         -------
         quanta : `Iterator` [ `Quantum` ]
-            Executed quanta.  At present, these will contain only unresolved
-            `DatasetRef` instances for output datasets, reflecting the state of
-            the quantum just before it was run (but after any adjustments for
-            predicted but now missing inputs).  This may change in the future
-            to include resolved output `DatasetRef` objects.
-
+            Executed quanta.
 
         Notes
         -----

--- a/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
+++ b/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
@@ -507,13 +507,11 @@ class SingleQuantumExecutor(QuantumExecutor):
             Task definition structure.
         """
         # Create a butler that operates in the context of a quantum
-        if self.butler is None:
-            butlerQC = ButlerQuantumContext.from_limited(limited_butler, quantum)
+        if not self.mock:
+            butlerQC = ButlerQuantumContext(limited_butler, quantum)
         else:
-            if self.mock:
-                butlerQC = MockButlerQuantumContext(self.butler, quantum)
-            else:
-                butlerQC = ButlerQuantumContext.from_full(self.butler, quantum)
+            assert self.butler is not None, "Full Butler instance requred for mock execution"
+            butlerQC = MockButlerQuantumContext(self.butler, quantum)
 
         # Get the input and output references for the task
         inputRefs, outputRefs = taskDef.connections.buildDatasetRefs(quantum)


### PR DESCRIPTION
All dataset references are resolved now, removing code that handled
unresolved refs.

ButlerQC now works with LimitedButler, there is no need for special case
for the full Butler.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
