### PR TITLE
DM-39434: Move QBB factory to a separate class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,3 +124,13 @@ convention = "numpy"
 # D200, D205 and D400 all complain if the first sentence of the docstring does
 # not fit on one line.
 add-ignore = ["D107", "D105", "D102", "D100", "D200", "D205", "D400"]
+
+[tool.coverage.report]
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+]


### PR DESCRIPTION
It was a nested method before and that interfered with pickle in multiprocessing on MacOS. Moved that to a separate callable class.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
