### PR TITLE
DM-39377: Assume that we always store task metadata

### DIFF
--- a/doc/changes/DM-39377.misc.md
+++ b/doc/changes/DM-39377.misc.md
@@ -1,0 +1,1 @@
+The `saveMetadata` configuration field is now ignored by executors in this package, metadata is assumed to be saved for each task.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Scientific/Engineering :: Astronomy",
 ]
 keywords = ["lsst"]

--- a/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
+++ b/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
@@ -329,7 +329,7 @@ class SingleQuantumExecutor(QuantumExecutor):
             # Skip/prune logic only works for full butler.
             return False
 
-        if self.skipExisting and taskDef.metadataDatasetName is not None:
+        if self.skipExisting:
             # Metadata output exists; this is sufficient to assume the previous
             # run was successful and should be skipped.
             [metadata_ref] = quantum.outputs[taskDef.metadataDatasetName]
@@ -539,17 +539,16 @@ class SingleQuantumExecutor(QuantumExecutor):
     def writeMetadata(
         self, quantum: Quantum, metadata: Any, taskDef: TaskDef, limited_butler: LimitedButler
     ) -> None:
-        if taskDef.metadataDatasetName is not None:
-            # DatasetRef has to be in the Quantum outputs, can lookup by name
-            try:
-                [ref] = quantum.outputs[taskDef.metadataDatasetName]
-            except LookupError as exc:
-                raise InvalidQuantumError(
-                    f"Quantum outputs is missing metadata dataset type {taskDef.metadataDatasetName};"
-                    " this could happen due to inconsistent options between QuantumGraph generation"
-                    " and execution"
-                ) from exc
-            limited_butler.put(metadata, ref)
+        # DatasetRef has to be in the Quantum outputs, can lookup by name
+        try:
+            [ref] = quantum.outputs[taskDef.metadataDatasetName]
+        except LookupError as exc:
+            raise InvalidQuantumError(
+                f"Quantum outputs is missing metadata dataset type {taskDef.metadataDatasetName};"
+                " this could happen due to inconsistent options between QuantumGraph generation"
+                " and execution"
+            ) from exc
+        limited_butler.put(metadata, ref)
 
     def initGlobals(self, quantum: Quantum) -> None:
         """Initialize global state needed for task execution.

--- a/tests/test_cliScript.py
+++ b/tests/test_cliScript.py
@@ -94,9 +94,6 @@ tasks:
             ShowInfoCmp(
                 "config",
                 """### Configuration for task `task'
-# Flag to enable/disable metadata saving for a task, enabled by default.
-config.saveMetadata=True
-
 # Flag to enable/disable saving of log output for a task, enabled by default.
 config.saveLogOutput=True
 


### PR DESCRIPTION
## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
