### PR TITLE
DM-39661: Add support for ExecutionResources

### DIFF
--- a/doc/changes/DM-39661.api.rst
+++ b/doc/changes/DM-39661.api.rst
@@ -1,0 +1,2 @@
+* Added new ``resources`` parameter to ``SingleQuantumExecutor``, ``SimplePipelineExecutor``, and ``SeparablePipelineExecutor`` constructors.
+  This optional parameter is a `~lsst.pipe.base.ExecutionResources` object and allows the execution context to be passed into the `~lsst.pipe.base.PipelinesTask.runQuantum` method.

--- a/doc/changes/DM-39661.feature.rst
+++ b/doc/changes/DM-39661.feature.rst
@@ -1,0 +1,2 @@
+* Added new command line options ``--cores-per-quantum`` and ``--memory-per-quantum``.
+  These can be used to pass some execution context into a quantum, allowing that quantum to change how it executes (maybe by using multiple threads).

--- a/python/lsst/ctrl/mpexec/cli/cmd/commands.py
+++ b/python/lsst/ctrl/mpexec/cli/cmd/commands.py
@@ -277,6 +277,8 @@ def pre_exec_init_qbb(repo: str, qgraph: str, **kwargs: Any) -> None:
 @ctrlMpExecOpts.fail_fast_option()
 @ctrlMpExecOpts.summary_option()
 @ctrlMpExecOpts.enable_implicit_threading_option()
+@ctrlMpExecOpts.cores_per_quantum_option()
+@ctrlMpExecOpts.memory_per_quantum_option()
 def run_qbb(repo: str, qgraph: str, **kwargs: Any) -> None:
     """Execute pipeline using Quantum-Backed Butler.
 

--- a/python/lsst/ctrl/mpexec/cli/opt/optionGroups.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/optionGroups.py
@@ -158,6 +158,8 @@ class execution_options(OptionGroup):  # noqa: N801
             ctrlMpExecOpts.graph_fixup_option(),
             ctrlMpExecOpts.summary_option(),
             ctrlMpExecOpts.enable_implicit_threading_option(),
+            ctrlMpExecOpts.cores_per_quantum_option(),
+            ctrlMpExecOpts.memory_per_quantum_option(),
         ]
 
 

--- a/python/lsst/ctrl/mpexec/cli/opt/options.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/options.py
@@ -383,6 +383,30 @@ enable_implicit_threading_option = MWOptionDecorator(
     is_flag=True,
 )
 
+cores_per_quantum_option = MWOptionDecorator(
+    "-n",
+    "--cores-per-quantum",
+    default=1,
+    help=unwrap(
+        """Number of cores available to each quantum when executing.
+        If '-j' is used each subprocess will be allowed to use this number of cores."""
+    ),
+    type=click.IntRange(min=1),
+)
+
+memory_per_quantum_option = MWOptionDecorator(
+    "--memory-per-quantum",
+    default="",
+    help=unwrap(
+        """Memory allocated for each quantum to use when executing.
+        This memory allocation is not enforced by the execution system and is purely advisory.
+        If '-j' used each subprocess will be allowed to use this amount of memory.
+        Units are allowed and the default units for a plain integer are MB.
+        For example: '3GB', '3000MB' and '3000' would all result in the same
+        memory limit. Default is for no limit."""
+    ),
+    type=str,
+)
 
 task_option = MWOptionDecorator(
     "-t",

--- a/python/lsst/ctrl/mpexec/cli/script/run.py
+++ b/python/lsst/ctrl/mpexec/cli/script/run.py
@@ -57,6 +57,8 @@ def run(  # type: ignore
     unmocked_dataset_types,
     mock_failure,
     enable_implicit_threading,
+    cores_per_quantum: int,
+    memory_per_quantum: str,
     **kwargs,
 ):
     """Implement the command line interface `pipetask run` subcommand.
@@ -159,6 +161,12 @@ def run(  # type: ignore
         If `True`, do not disable implicit threading by third-party libraries.
         Implicit threading is always disabled during actual quantum execution
         if ``processes > 1``.
+    cores_per_quantum : `int`
+        Number of cores that can be used by each quantum.
+    memory_per_quantum : `str`
+        Amount of memory that each quantum can be allowed to use. Empty string
+        implies no limit. The string can be either a single integer (implying
+        units of MB) or a combination of number and unit.
     kwargs : `dict` [`str`, `str`]
         Ignored; click commands may accept options for more than one script
         function and pass all the option kwargs to each of the script functions
@@ -191,6 +199,8 @@ def run(  # type: ignore
         summary=summary,
         # Mock options only used by qgraph.
         enable_implicit_threading=enable_implicit_threading,
+        cores_per_quantum=cores_per_quantum,
+        memory_per_quantum=memory_per_quantum,
     )
 
     f = CmdLineFwk()

--- a/python/lsst/ctrl/mpexec/cli/script/run_qbb.py
+++ b/python/lsst/ctrl/mpexec/cli/script/run_qbb.py
@@ -39,6 +39,8 @@ def run_qbb(
     fail_fast: bool,
     summary: str | None,
     enable_implicit_threading: bool,
+    cores_per_quantum: int,
+    memory_per_quantum: str,
 ) -> None:
     """Implement the command line interface ``pipetask run-qbb`` subcommand.
 
@@ -82,6 +84,12 @@ def run_qbb(
         If `True`, do not disable implicit threading by third-party libraries.
         Implicit threading is always disabled during actual quantum execution
         if ``processes > 1``.
+    cores_per_quantum : `int`
+        Number of cores that can be used by each quantum.
+    memory_per_quantum : `str`
+        Amount of memory that each quantum can be allowed to use. Empty string
+        implies no limit. The string can be either a single integer (implying
+        units of MB) or a combination of number and unit.
     """
     args = SimpleNamespace(
         butler_config=butler_config,
@@ -98,6 +106,8 @@ def run_qbb(
         fail_fast=fail_fast,
         summary=summary,
         enable_implicit_threading=enable_implicit_threading,
+        cores_per_quantum=cores_per_quantum,
+        memory_per_quantum=memory_per_quantum,
     )
 
     f = CmdLineFwk()

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -712,30 +712,9 @@ class CmdLineFwk:
         resources : `~lsst.pipe.base.ExecutionResources`
             The resources available to each quantum.
         """
-        # The memory per quantum is a string that needs to be parsed.
-        mem = None
-
-        if args.memory_per_quantum:
-            try:
-                mem = int(args.memory_per_quantum)
-            except ValueError:
-                pass
-            else:
-                mem *= u.MB  # Default is for megabytes.
-
-            if mem is None:
-                try:
-                    mem = u.Quantity(args.memory_per_quantum)
-                except Exception as e:
-                    _LOG.warning(
-                        "Unable to parse the quantity from --memory-per-quantum parameter of %r. "
-                        "Ignoring the parameter. Got error: %s",
-                        args.memory_per_quantum,
-                        e,
-                    )
-
-        # This could fail if someone specifies a unit of meters or tesla, etc.
-        return ExecutionResources(num_cores=args.cores_per_quantum, max_mem=mem)
+        return ExecutionResources(
+            num_cores=args.cores_per_quantum, max_mem=args.memory_per_quantum, default_mem_units=u.MB
+        )
 
     def runPipeline(
         self,

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -750,7 +750,7 @@ class CmdLineFwk:
         # Enable lsstDebug debugging. Note that this is done once in the
         # main process before PreExecInit and it is also repeated before
         # running each task in SingleQuantumExecutor (which may not be
-        # needed if `multipocessing` always uses fork start method).
+        # needed if `multiprocessing` always uses fork start method).
         if args.enableLsstDebug:
             try:
                 _LOG.debug("Will try to import debug.py")

--- a/python/lsst/ctrl/mpexec/separablePipelineExecutor.py
+++ b/python/lsst/ctrl/mpexec/separablePipelineExecutor.py
@@ -96,6 +96,8 @@ class SeparablePipelineExecutor:
     task_factory : `lsst.pipe.base.TaskFactory`, optional
         A custom task factory for use in pre-execution and execution. By
         default, a new instance of `lsst.ctrl.mpexec.TaskFactory` is used.
+    resources : `~lsst.pipe.base.ExecutionResources`
+        The resources available to each quantum being executed.
     """
 
     def __init__(
@@ -104,6 +106,7 @@ class SeparablePipelineExecutor:
         clobber_output: bool = False,
         skip_existing_in: Iterable[str] | None = None,
         task_factory: lsst.pipe.base.TaskFactory | None = None,
+        resources: lsst.pipe.base.ExecutionResources | None = None,
     ):
         self._butler = Butler(butler=butler, collections=butler.collections, run=butler.run)
         if not self._butler.collections:
@@ -115,6 +118,7 @@ class SeparablePipelineExecutor:
         self._skip_existing_in = list(skip_existing_in) if skip_existing_in else []
 
         self._task_factory = task_factory if task_factory else TaskFactory()
+        self.resources = resources
 
     def pre_execute_qgraph(
         self,
@@ -254,6 +258,7 @@ class SeparablePipelineExecutor:
                 self._task_factory,
                 skipExistingIn=self._skip_existing_in,
                 clobberOutputs=self._clobber_output,
+                resources=self.resources,
             )
             graph_executor = MPGraphExecutor(
                 numProc=math.ceil(0.8 * multiprocessing.cpu_count()),

--- a/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
+++ b/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
@@ -44,6 +44,7 @@ from lsst.daf.butler import (
 from lsst.daf.butler.registry.wildcards import CollectionWildcard
 from lsst.pipe.base import (
     AdjustQuantumHelper,
+    ExecutionResources,
     Instrument,
     InvalidQuantumError,
     NoWorkFound,
@@ -106,6 +107,8 @@ class SingleQuantumExecutor(QuantumExecutor):
         A method that creates a `~lsst.daf.butler.LimitedButler` instance
         for a given Quantum. This parameter must be defined if ``butler`` is
         `None`. If ``butler`` is not `None` then this parameter is ignored.
+    resources : `~lsst.pipe.base.ExecutionResources`, optional
+        The resources available to this quantum when executing.
     """
 
     def __init__(
@@ -117,6 +120,7 @@ class SingleQuantumExecutor(QuantumExecutor):
         enableLsstDebug: bool = False,
         exitOnKnownError: bool = False,
         limited_butler_factory: Callable[[Quantum], LimitedButler] | None = None,
+        resources: ExecutionResources | None = None,
     ):
         self.butler = butler
         self.taskFactory = taskFactory
@@ -125,6 +129,7 @@ class SingleQuantumExecutor(QuantumExecutor):
         self.exitOnKnownError = exitOnKnownError
         self.limited_butler_factory = limited_butler_factory
         self.report: QuantumReport | None = None
+        self.resources = resources
 
         if self.butler is None:
             assert limited_butler_factory is not None, "limited_butler_factory is needed when butler is None"
@@ -445,7 +450,7 @@ class SingleQuantumExecutor(QuantumExecutor):
             Task definition structure.
         """
         # Create a butler that operates in the context of a quantum
-        butlerQC = QuantumContext(limited_butler, quantum)
+        butlerQC = QuantumContext(limited_butler, quantum, resources=self.resources)
 
         # Get the input and output references for the task
         inputRefs, outputRefs = taskDef.connections.buildDatasetRefs(quantum)

--- a/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
+++ b/python/lsst/ctrl/mpexec/singleQuantumExecutor.py
@@ -44,11 +44,11 @@ from lsst.daf.butler import (
 from lsst.daf.butler.registry.wildcards import CollectionWildcard
 from lsst.pipe.base import (
     AdjustQuantumHelper,
-    ButlerQuantumContext,
     Instrument,
     InvalidQuantumError,
     NoWorkFound,
     PipelineTask,
+    QuantumContext,
     RepeatableQuantumError,
     TaskDef,
     TaskFactory,
@@ -445,7 +445,7 @@ class SingleQuantumExecutor(QuantumExecutor):
             Task definition structure.
         """
         # Create a butler that operates in the context of a quantum
-        butlerQC = ButlerQuantumContext(limited_butler, quantum)
+        butlerQC = QuantumContext(limited_butler, quantum)
 
         # Get the input and output references for the task
         inputRefs, outputRefs = taskDef.connections.buildDatasetRefs(quantum)

--- a/tests/test_cmdLineFwk.py
+++ b/tests/test_cmdLineFwk.py
@@ -468,22 +468,16 @@ class CmdLineFwkTestCase(unittest.TestCase):
 
         for params, num_cores, max_mem in (
             ((None, None), 1, None),
-            ((5, None), 5, None),
+            ((5, ""), 5, None),
             ((None, "50"), 1, 50 * u.MB),
             ((5, "50 GB"), 5, 50 * u.GB),
-            ((None, "GB 50"), 1, None),  # Parse failure of unit.
         ):
             kwargs = {}
             for k, v in zip(("cores_per_quantum", "memory_per_quantum"), params):
                 if v is not None:
                     kwargs[k] = v
             args = _makeArgs(**kwargs)
-            if isinstance(params[1], str) and max_mem is None:
-                # Parse failure should log.
-                with self.assertLogs("lsst.ctrl.mpexec.cmdLineFwk", "WARNING"):
-                    res = fwk._make_execution_resources(args)
-            else:
-                res = fwk._make_execution_resources(args)
+            res = fwk._make_execution_resources(args)
             self.assertEqual(res.num_cores, num_cores)
             self.assertEqual(res.max_mem, max_mem)
 


### PR DESCRIPTION
Requires lsst/pipe_base#344

Add `--cores-per-quantum` and `--memory-per-quantum` options.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
