### PR TITLE
DM-39672: make it possible to force failures in mock pipelines on the command-line

### DIFF
--- a/doc/changes/DM-39672.feature.md
+++ b/doc/changes/DM-39672.feature.md
@@ -1,0 +1,1 @@
+Make it possible to force failures in mocked pipelines from the command-line.

--- a/python/lsst/ctrl/mpexec/cli/opt/optionGroups.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/optionGroups.py
@@ -115,6 +115,7 @@ class qgraph_options(OptionGroup):  # noqa: N801
             ctrlMpExecOpts.dataset_query_constraint(),
             ctrlMpExecOpts.qgraph_header_data_option(),
             ctrlMpExecOpts.mock_option(),
+            ctrlMpExecOpts.mock_failure_option(),
             ctrlMpExecOpts.unmocked_dataset_types_option(),
             coverage_options(),
         ]

--- a/python/lsst/ctrl/mpexec/cli/opt/optionGroups.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/optionGroups.py
@@ -115,8 +115,8 @@ class qgraph_options(OptionGroup):  # noqa: N801
             ctrlMpExecOpts.dataset_query_constraint(),
             ctrlMpExecOpts.qgraph_header_data_option(),
             ctrlMpExecOpts.mock_option(),
-            coverage_options(),
             ctrlMpExecOpts.unmocked_dataset_types_option(),
+            coverage_options(),
         ]
 
 

--- a/python/lsst/ctrl/mpexec/cli/script/qgraph.py
+++ b/python/lsst/ctrl/mpexec/cli/script/qgraph.py
@@ -58,6 +58,7 @@ def qgraph(  # type: ignore
     show_qgraph_header=False,
     mock=False,
     unmocked_dataset_types=(),
+    mock_failure=(),
     **kwargs,
 ):
     """Implement the command line interface `pipetask qgraph` subcommand.
@@ -162,6 +163,8 @@ def qgraph(  # type: ignore
         If True, use a mocked version of the pipeline.
     unmocked_dataset_types : `collections.abc.Sequence` [ `str` ], optional
         List of overall-input dataset types that should not be mocked.
+    mock_failure : `~collections.abc.Sequence`, optional
+        List of quanta that should raise exceptions.
     kwargs : `dict` [`str`, `str`]
         Ignored; click commands may accept options for more than one script
         function and pass all the option kwargs to each of the script functions
@@ -200,6 +203,7 @@ def qgraph(  # type: ignore
         show_qgraph_header=show_qgraph_header,
         mock=mock,
         unmocked_dataset_types=list(unmocked_dataset_types),
+        mock_failure=mock_failure,
     )
 
     f = CmdLineFwk()

--- a/python/lsst/ctrl/mpexec/cli/script/run.py
+++ b/python/lsst/ctrl/mpexec/cli/script/run.py
@@ -55,6 +55,7 @@ def run(  # type: ignore
     summary,
     mock,
     unmocked_dataset_types,
+    mock_failure,
     enable_implicit_threading,
     **kwargs,
 ):
@@ -152,6 +153,8 @@ def run(  # type: ignore
     unmocked_dataset_types : `collections.abc.Sequence` [ `str` ]
         List of overall-input dataset types that should not be mocked.
         Ignored if an existing QuantumGraph is provided.
+    mock_failure : `~collections.abc.Sequence`, optional
+        List of quanta that should raise exceptions.
     enable_implicit_threading : `bool`, optional
         If `True`, do not disable implicit threading by third-party libraries.
         Implicit threading is always disabled during actual quantum execution
@@ -186,8 +189,7 @@ def run(  # type: ignore
         fail_fast=fail_fast,
         clobber_outputs=clobber_outputs,
         summary=summary,
-        mock=mock,
-        unmocked_dataset_types=unmocked_dataset_types,
+        # Mock options only used by qgraph.
         enable_implicit_threading=enable_implicit_threading,
     )
 

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -595,7 +595,11 @@ class CmdLineFwk:
             if args.mock:
                 from lsst.pipe.base.tests.mocks import mock_task_defs
 
-                task_defs = mock_task_defs(task_defs, unmocked_dataset_types=args.unmocked_dataset_types)
+                task_defs = mock_task_defs(
+                    task_defs,
+                    unmocked_dataset_types=args.unmocked_dataset_types,
+                    force_failures=args.mock_failure,
+                )
             # make execution plan (a.k.a. DAG) for pipeline
             graphBuilder = GraphBuilder(
                 butler.registry,


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
