### PR TITLE
DM-40254: Expand output of `--show=graph` option

### DIFF
--- a/doc/changes/DM-40254.feature.md
+++ b/doc/changes/DM-40254.feature.md
@@ -1,0 +1,1 @@
+The output of the `pipetask ... --show=graph` now includes extended information about dataset references and their related datastore records.

--- a/doc/changes/README.rst
+++ b/doc/changes/README.rst
@@ -13,7 +13,6 @@ The ``<TYPE>`` should be one of:
 * ``perf``: A performance enhancement.
 * ``doc``: A documentation improvement.
 * ``removal``: An API removal or deprecation.
-* ``other``: Other Changes and Additions of interest to general users.
 * ``misc``: Changes that are of minor interest.
 
 An example file name would therefore look like ``DM-30291.misc.rst``.


### PR DESCRIPTION
The output now includes more complete information about dataset refs and also their related datastore records if they appear in the quantum graph.

## Checklist

- [ ] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
