### PR TITLE
DM-35599: Use a transfer option that does not include -t

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,8 +6,8 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: check-toml
-  - repo: https://github.com/psf/black
-    rev: 23.7.0
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.9.1
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -22,6 +22,6 @@ repos:
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.0.282
+    rev: v0.0.289
     hooks:
       - id: ruff

--- a/doc/changes/DM-35599.bugfix.rst
+++ b/doc/changes/DM-35599.bugfix.rst
@@ -1,0 +1,2 @@
+Removed shadowing of ``pipetask build -t`` by ``pipetask qgraph -t``.
+``-t`` now means ``--task`` rather than ``--transfer``.

--- a/python/lsst/ctrl/mpexec/cli/opt/optionGroups.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/optionGroups.py
@@ -40,7 +40,7 @@ __all__ = (
 import click
 import lsst.daf.butler.cli.opt as dafButlerOpts
 import lsst.pipe.base.cli.opt as pipeBaseOpts
-from lsst.daf.butler.cli.opt import transfer_option
+from lsst.daf.butler.cli.opt import transfer_option_no_short
 from lsst.daf.butler.cli.utils import OptionGroup, option_section, unwrap
 
 from . import options as ctrlMpExecOpts
@@ -112,7 +112,7 @@ class qgraph_options(OptionGroup):  # noqa: N801
             ctrlMpExecOpts.save_execution_butler_option(),
             ctrlMpExecOpts.clobber_execution_butler_option(),
             ctrlMpExecOpts.target_datastore_root_option(),
-            transfer_option(
+            transfer_option_no_short(
                 help=unwrap(
                     """Data transfer mode for the execution butler datastore.
                     Defaults to "copy" if --target-datastore-root is provided.


### PR DESCRIPTION
This stops it shadowing --task.

Requires lsst/daf_butler#888

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
