### PR TITLE
DM-41116: Few updates fiollowing Butler interface change

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -31,6 +31,10 @@ ignore_errors = True
 ignore_missing_imports = False
 ignore_errors = True
 
+[mypy-lsst.pipe.base.*]
+ignore_missing_imports = False
+ignore_errors = True
+
 [mypy-lsst.ctrl.mpexec.*]
 ignore_missing_imports = False
 ignore_errors = False
@@ -40,7 +44,3 @@ strict_equality = True
 warn_unreachable = True
 # Until we switch to solely pydantic v2
 warn_unused_ignores = False
-
-[mypy-lsst.ctrl.mpexec.examples.*]
-ignore_missing_imports = False
-ignore_errors = True

--- a/python/lsst/ctrl/mpexec/cli/script/build.py
+++ b/python/lsst/ctrl/mpexec/cli/script/build.py
@@ -110,7 +110,7 @@ def build(  # type: ignore
     pipeline = f.makePipeline(args)
 
     if butler_config is not None:
-        butler = Butler(butler_config, writeable=False)
+        butler = Butler.from_config(butler_config, writeable=False)
     else:
         butler = None
 

--- a/python/lsst/ctrl/mpexec/cli/script/cleanup.py
+++ b/python/lsst/ctrl/mpexec/cli/script/cleanup.py
@@ -76,7 +76,7 @@ class CleanupResult(ConfirmableResult):
         return msg
 
     def on_confirmation(self) -> None:
-        butler = Butler(self.butler_config, writeable=True)
+        butler = Butler.from_config(self.butler_config, writeable=True)
         with butler.transaction():
             for collection in self.others_to_remove:
                 butler.registry.removeCollection(collection)
@@ -109,7 +109,7 @@ def cleanup(
     collection : str
         The name of the chained collection.
     """
-    butler = Butler(butler_config)
+    butler = Butler.from_config(butler_config)
     result = CleanupResult(butler_config)
     try:
         to_keep = set(butler.registry.getCollectionChain(collection))

--- a/python/lsst/ctrl/mpexec/cli/script/purge.py
+++ b/python/lsst/ctrl/mpexec/cli/script/purge.py
@@ -120,7 +120,7 @@ class PurgeResult(ConfirmableResult):
         if self.failure:
             # This should not happen, it is a logic error.
             raise RuntimeError("Can not purge, there were errors preparing collections.")
-        butler = Butler(self.butler_config, writeable=True)
+        butler = Butler.from_config(self.butler_config, writeable=True)
         with butler.transaction():
             for c in itertools.chain(self.others_to_remove, self.chains_to_remove):
                 butler.registry.removeCollection(c)
@@ -254,7 +254,7 @@ def purge(
         to remove the datasets after confirmation, if needed.
     """
     result = PurgeResult(butler_config)
-    butler = Butler(butler_config)
+    butler = Butler.from_config(butler_config)
 
     try:
         collection_type = butler.registry.getCollectionType(collection)

--- a/python/lsst/ctrl/mpexec/separablePipelineExecutor.py
+++ b/python/lsst/ctrl/mpexec/separablePipelineExecutor.py
@@ -114,7 +114,7 @@ class SeparablePipelineExecutor:
         task_factory: lsst.pipe.base.TaskFactory | None = None,
         resources: lsst.pipe.base.ExecutionResources | None = None,
     ):
-        self._butler = Butler(butler=butler, collections=butler.collections, run=butler.run)
+        self._butler = Butler.from_config(butler=butler, collections=butler.collections, run=butler.run)
         if not self._butler.collections:
             raise ValueError("Butler must specify input collections for pipeline.")
         if not self._butler.run:

--- a/python/lsst/ctrl/mpexec/simple_pipeline_executor.py
+++ b/python/lsst/ctrl/mpexec/simple_pipeline_executor.py
@@ -129,7 +129,7 @@ class SimplePipelineExecutor:
             output_run = f"{output}/{Instrument.makeCollectionTimestamp()}"
         # Make initial butler with no collections, since we haven't created
         # them yet.
-        butler = Butler(root, writeable=True)
+        butler = Butler.from_config(root, writeable=True)
         butler.registry.registerCollection(output_run, CollectionType.RUN)
         butler.registry.registerCollection(output, CollectionType.CHAINED)
         collections = [output_run]
@@ -137,7 +137,7 @@ class SimplePipelineExecutor:
         butler.registry.setCollectionChain(output, collections)
         # Remake butler to let it infer default data IDs from collections, now
         # that those collections exist.
-        return Butler(butler=butler, collections=[output], run=output_run)
+        return Butler.from_config(butler=butler, collections=[output], run=output_run)
 
     @classmethod
     def from_pipeline_filename(

--- a/tests/test_cliCmdCleanup.py
+++ b/tests/test_cliCmdCleanup.py
@@ -84,7 +84,7 @@ class CleanupCollectionTest(unittest.TestCase):
         self.assertIn("Will remove:\n  runs: \n  others: ingest\n", result.output)
         self.assertIn("Done.", result.output)
 
-        butler = Butler(self.root)
+        butler = Butler.from_config(self.root)
         self.assertEqual(set(butler.registry.queryCollections()), {"in", "ingest/run"})
 
     def test_nonExistantCollection(self):

--- a/tests/test_separablePipelineExecutor.py
+++ b/tests/test_separablePipelineExecutor.py
@@ -57,13 +57,13 @@ class SeparablePipelineExecutorTests(lsst.utils.tests.TestCase):
         config = lsst.daf.butler.Butler.makeRepo(
             repodir.name, standalone=True, searchPaths=[os.path.join(TESTDIR, "config")]
         )
-        butler = lsst.daf.butler.Butler(config, writeable=True)
+        butler = lsst.daf.butler.Butler.from_config(config, writeable=True)
         output = "fake"
         output_run = f"{output}/{Instrument.makeCollectionTimestamp()}"
         butler.registry.registerCollection(output_run, lsst.daf.butler.CollectionType.RUN)
         butler.registry.registerCollection(output, lsst.daf.butler.CollectionType.CHAINED)
         butler.registry.setCollectionChain(output, [output_run])
-        self.butler = lsst.daf.butler.Butler(butler=butler, collections=[output], run=output_run)
+        self.butler = lsst.daf.butler.Butler.from_config(butler=butler, collections=[output], run=output_run)
 
         butlerTests.addDatasetType(self.butler, "input", set(), "StructuredDataDict")
         butlerTests.addDatasetType(self.butler, "intermediate", set(), "StructuredDataDict")
@@ -204,13 +204,13 @@ class SeparablePipelineExecutorTests(lsst.utils.tests.TestCase):
         self.assertTrue(self.butler.exists(PipelineDatasetTypes.packagesDatasetName, {}))
 
     def test_init_badinput(self):
-        butler = lsst.daf.butler.Butler(butler=self.butler, collections=[], run="foo")
+        butler = lsst.daf.butler.Butler.from_config(butler=self.butler, collections=[], run="foo")
 
         with self.assertRaises(ValueError):
             SeparablePipelineExecutor(butler)
 
     def test_init_badoutput(self):
-        butler = lsst.daf.butler.Butler(butler=self.butler, collections=["foo"])
+        butler = lsst.daf.butler.Butler.from_config(butler=self.butler, collections=["foo"])
 
         with self.assertRaises(ValueError):
             SeparablePipelineExecutor(butler)


### PR DESCRIPTION
Butler is now an abstract class, and preferred way to instanciate butlers
is `Butler.from_config`. Execution butler requires a `DirectButler` instance,
updated the code to reflect that (somewhat hackish, but execution butler is
going to disappear any minute now or next year).

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
