### PR TITLE
DM-41832: Use spawn as start method, deprecate fork option

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.11"]
 
     steps:
       - uses: actions/checkout@v3
@@ -79,7 +79,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.10'
+          python-version: '3.11'
           cache: "pip"
           cache-dependency-path: "setup.cfg"
 
@@ -35,7 +35,7 @@ jobs:
         run: pip install --no-deps -v .
 
       - name: Install documenteer
-        run: pip install 'documenteer[pipelines]<0.8'
+        run: pip install 'documenteer[pipelines]>=0.8'
 
       - name: Build documentation
         working-directory: ./doc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: check-toml
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.9.1
+    rev: 23.11.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -22,6 +22,6 @@ repos:
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.0.289
+    rev: v0.1.6
     hooks:
       - id: ruff

--- a/doc/changes/DM-41832.removal.md
+++ b/doc/changes/DM-41832.removal.md
@@ -1,0 +1,3 @@
+Support for fork option in `pipetask run` has been removed as unsafe.
+Default start option now is `spawn`, `forkserver` is also available.
+The `fork` option is still present in CLI for compatibility, but is deprecated and replaced by `spawn` if specified.

--- a/python/lsst/ctrl/mpexec/cli/opt/options.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/options.py
@@ -431,7 +431,7 @@ start_method_option = MWOptionDecorator(
     type=click.Choice(choices=["spawn", "fork", "forkserver"]),
     help=(
         "Multiprocessing start method, default is platform-specific. "
-        "Fork method is now deprecated, spawn is used instead if fork is selected."
+        "Fork method is no longer supported, spawn is used instead if fork is selected."
     ),
 )
 

--- a/python/lsst/ctrl/mpexec/cli/opt/options.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/options.py
@@ -429,7 +429,10 @@ start_method_option = MWOptionDecorator(
     "--start-method",
     default=None,
     type=click.Choice(choices=["spawn", "fork", "forkserver"]),
-    help="Multiprocessing start method, default is platform-specific.",
+    help=(
+        "Multiprocessing start method, default is platform-specific. "
+        "Fork method is now deprecated, spawn is used instead if fork is selected."
+    ),
 )
 
 

--- a/python/lsst/ctrl/mpexec/cli/script/run.py
+++ b/python/lsst/ctrl/mpexec/cli/script/run.py
@@ -185,7 +185,7 @@ def run(  # type: ignore
     # Fork option still exists for compatibility but we use spawn instead.
     if start_method == "fork":
         start_method = "spawn"
-        _log.warning("Option --start-method=fork is deprecated and unsafe, will use spawn instead.")
+        _log.warning("Option --start-method=fork is unsafe and no longer supported, will use spawn instead.")
 
     args = SimpleNamespace(
         pdb=pdb,

--- a/python/lsst/ctrl/mpexec/cli/script/run.py
+++ b/python/lsst/ctrl/mpexec/cli/script/run.py
@@ -182,6 +182,11 @@ def run(  # type: ignore
         function and pass all the option kwargs to each of the script functions
         which ignore these unused kwargs.
     """
+    # Fork option still exists for compatibility but we use spawn instead.
+    if start_method == "fork":
+        start_method = "spawn"
+        _log.warning("Option --start-method=fork is deprecated and unsafe, will use spawn instead.")
+
     args = SimpleNamespace(
         pdb=pdb,
         graph_fixup=graph_fixup,

--- a/python/lsst/ctrl/mpexec/cli/script/run_qbb.py
+++ b/python/lsst/ctrl/mpexec/cli/script/run_qbb.py
@@ -103,7 +103,7 @@ def run_qbb(
     # Fork option still exists for compatibility but we use spawn instead.
     if start_method == "fork":
         start_method = "spawn"
-        _log.warning("Option --start-method=fork is deprecated and unsafe, will use spawn instead.")
+        _log.warning("Option --start-method=fork is unsafe and no longer supported, will use spawn instead.")
 
     args = SimpleNamespace(
         butler_config=butler_config,

--- a/python/lsst/ctrl/mpexec/cli/script/run_qbb.py
+++ b/python/lsst/ctrl/mpexec/cli/script/run_qbb.py
@@ -25,9 +25,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
 from types import SimpleNamespace
 
 from ... import CmdLineFwk, TaskFactory
+
+_log = logging.getLogger(__name__)
 
 
 def run_qbb(
@@ -97,6 +100,11 @@ def run_qbb(
         implies no limit. The string can be either a single integer (implying
         units of MB) or a combination of number and unit.
     """
+    # Fork option still exists for compatibility but we use spawn instead.
+    if start_method == "fork":
+        start_method = "spawn"
+        _log.warning("Option --start-method=fork is deprecated and unsafe, will use spawn instead.")
+
     args = SimpleNamespace(
         butler_config=butler_config,
         qgraph=qgraph,


### PR DESCRIPTION
Fork became unusable, switching default start method to spawn. Forkserver
option is still available, fork option is kept in CLI for compatibility
but we issue a warning and switch to spawn if fork is given.

## Checklist

- [X] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
