### PR TITLE
DM-41962: Use storage classes from QG in PreExecInit.

### DIFF
--- a/doc/changes/DM-41962.bugfix.md
+++ b/doc/changes/DM-41962.bugfix.md
@@ -1,0 +1,4 @@
+Fix a storage class bug in registering dataset types in ``pipetask run``.
+
+Prior to this fix, the presence of multiple storage classes being associated with the same dataset type in a pipeline could cause the registered dataset type's storage class to be random and nondeterministic in regular `pipetask run` execution (but not quantum-backed butler execution).
+It now follows the rules set by `PipelineGraph`, in which the definition in the task that produces the dataset wins.

--- a/python/lsst/ctrl/mpexec/preExecInit.py
+++ b/python/lsst/ctrl/mpexec/preExecInit.py
@@ -411,11 +411,12 @@ class PreExecInit(PreExecInitBase):
         ):
             dataset_types = [
                 (
-                    # The registry dataset types do not include components,
-                    # but we don't support storage class overrides for those
-                    # in other contexts anyway.
+                    # The registry dataset types do not include components, but
+                    # we don't support storage class overrides for those in
+                    # other contexts anyway, and custom-built QGs may not have
+                    # the registry dataset types field populated at all.x
                     dataset_type.overrideStorageClass(registry_storage_classes[dataset_type.name])
-                    if not dataset_type.isComponent()
+                    if dataset_type.name in registry_storage_classes
                     else dataset_type
                 )
                 for dataset_type in dataset_types

--- a/tests/test_simple_pipeline_executor.py
+++ b/tests/test_simple_pipeline_executor.py
@@ -165,7 +165,12 @@ class SimplePipelineExecutorTests(lsst.utils.tests.TestCase):
         return executor
 
     def _test_logs(self, log_output, input_type_a, output_type_a, input_type_b, output_type_b):
-        """Check the expected input types received by tasks A and B"""
+        """Check the expected input types received by tasks A and B.
+
+        Note that these are the types as seen from the perspective of the task,
+        so they must be consistent with the task's connections, but may not be
+        consistent with the registry dataset types.
+        """
         all_logs = "\n".join(log_output)
         self.assertIn(f"lsst.a:Run method given data of type: {input_type_a}", all_logs)
         self.assertIn(f"lsst.b:Run method given data of type: {input_type_b}", all_logs)
@@ -191,12 +196,6 @@ class SimplePipelineExecutorTests(lsst.utils.tests.TestCase):
 
     def test_from_pipeline_intermediates_differ(self):
         """Run pipeline but intermediates definition in registry differs."""
-        executor = self._configure_pipeline(
-            NoDimensionsTestTask.ConfigClass,
-            NoDimensionsTestTask.ConfigClass,
-            storageClass_b="TaskMetadataLike",
-        )
-
         # Pre-define the "intermediate" storage class to be something that is
         # like a dict but is not a dict. This will fail unless storage
         # class conversion is supported in put and get.
@@ -207,7 +206,11 @@ class SimplePipelineExecutorTests(lsst.utils.tests.TestCase):
                 storageClass="TaskMetadataLike",
             )
         )
-
+        executor = self._configure_pipeline(
+            NoDimensionsTestTask.ConfigClass,
+            NoDimensionsTestTask.ConfigClass,
+            storageClass_b="TaskMetadataLike",
+        )
         with self.assertLogs("lsst", level="INFO") as cm:
             quanta = executor.run(register_dataset_types=True, save_versions=False)
         # A dict is given to task a without change.
@@ -221,8 +224,8 @@ class SimplePipelineExecutorTests(lsst.utils.tests.TestCase):
         self._test_logs(cm.output, "dict", "dict", "dict", "lsst.pipe.base.TaskMetadata")
 
         self.assertEqual(len(quanta), 2)
-        self.assertEqual(self.butler.get("intermediate").to_dict(), {"zero": 0, "one": 1})
-        self.assertEqual(self.butler.get("output").to_dict(), {"zero": 0, "one": 1, "two": 2})
+        self.assertEqual(self.butler.get("intermediate"), TaskMetadata.from_dict({"zero": 0, "one": 1}))
+        self.assertEqual(self.butler.get("output"), TaskMetadata.from_dict({"zero": 0, "one": 1, "two": 2}))
 
     def test_from_pipeline_output_differ(self):
         """Run pipeline but output definition in registry differs."""
@@ -236,13 +239,11 @@ class SimplePipelineExecutorTests(lsst.utils.tests.TestCase):
                 storageClass="TaskMetadataLike",
             )
         )
-
         executor = self._configure_pipeline(
             NoDimensionsTestTask.ConfigClass,
             NoDimensionsTestTask.ConfigClass,
             storageClass_a="TaskMetadataLike",
         )
-
         with self.assertLogs("lsst", level="INFO") as cm:
             quanta = executor.run(register_dataset_types=True, save_versions=False)
         # a has been told to return a TaskMetadata but this will convert to
@@ -251,8 +252,8 @@ class SimplePipelineExecutorTests(lsst.utils.tests.TestCase):
         self._test_logs(cm.output, "dict", "lsst.pipe.base.TaskMetadata", "dict", "dict")
 
         self.assertEqual(len(quanta), 2)
-        self.assertEqual(self.butler.get("intermediate").to_dict(), {"zero": 0, "one": 1})
-        self.assertEqual(self.butler.get("output").to_dict(), {"zero": 0, "one": 1, "two": 2})
+        self.assertEqual(self.butler.get("intermediate"), TaskMetadata.from_dict({"zero": 0, "one": 1}))
+        self.assertEqual(self.butler.get("output"), TaskMetadata.from_dict({"zero": 0, "one": 1, "two": 2}))
 
     def test_from_pipeline_input_differ(self):
         """Run pipeline but input definition in registry differs."""
@@ -268,8 +269,11 @@ class SimplePipelineExecutorTests(lsst.utils.tests.TestCase):
         self.assertEqual(self.butler.get("intermediate"), {"zero": 0, "one": 1})
         self.assertEqual(self.butler.get("output"), {"zero": 0, "one": 1, "two": 2})
 
-    def test_from_pipeline_incompatible(self):
-        """Run pipeline but definitions are not compatible."""
+    def test_from_pipeline_inconsistent_dataset_types(self):
+        """Generate the QG (by initializing the executor), then register the
+        dataset type with a different storage class than the QG should have
+        predicted, to make sure execution fails as it should.
+        """
         executor = self._configure_pipeline(
             NoDimensionsTestTask.ConfigClass, NoDimensionsTestTask.ConfigClass
         )


### PR DESCRIPTION
PipelineDatasetTypes does not preserve storage classes (that's why it's being deprecated).

## Checklist

- [x] ran Jenkins (failed due to something unrelated; `main` is broken in at least two ways right now, and this ticket fixes one of them)
- [x] added a release note for user-visible changes to `doc/changes`
