### PR TITLE
DM-43363: Remove extraneous files from pipetask report tests

### DIFF
--- a/doc/changes/DM-43363.bugfix.md
+++ b/doc/changes/DM-43363.bugfix.md
@@ -1,0 +1,3 @@
+Fix the `--show-errors` option in `pipetask report`. 
+
+Correctly pass the option to the function as a flag. Then, in testing, use the `--show-errors` option to avoid saving yaml files to disk without adequate cleanup.

--- a/python/lsst/ctrl/mpexec/cli/cmd/commands.py
+++ b/python/lsst/ctrl/mpexec/cli/cmd/commands.py
@@ -331,7 +331,14 @@ def update_graph_run(
 @ctrlMpExecOpts.qgraph_argument()
 @click.option("--full-output-filename", default="", help="Summarize report in a yaml file")
 @click.option("--logs/--no-logs", default=True, help="Get butler log datasets for extra information.")
-@click.option("--show-errors", default=False, help="Pretty-print a dict of errors from failed quanta.")
+@click.option(
+    "--show-errors",
+    is_flag=True,
+    default=False,
+    help="Pretty-print a dict of errors from failed"
+    " quanta to the screen. Note: the default is to output a yaml file with error information"
+    " (data_ids and associated messages) to the current working directory instead.",
+)
 def report(
     repo: str, qgraph: str, full_output_filename: str = "", logs: bool = True, show_errors: bool = False
 ) -> None:
@@ -342,4 +349,4 @@ def report(
 
     QGRAPH is the URL to a serialized Quantum Graph file.
     """
-    script.report(repo, qgraph, full_output_filename, logs)
+    script.report(repo, qgraph, full_output_filename, logs, show_errors)

--- a/tests/test_cliCmdReport.py
+++ b/tests/test_cliCmdReport.py
@@ -85,7 +85,7 @@ class ReportTest(unittest.TestCase):
 
         result_hr = self.runner.invoke(
             pipetask_cli,
-            ["report", self.root, graph_uri, "--no-logs"],
+            ["report", self.root, graph_uri, "--no-logs", "--show-errors"],
             input="no",
         )
 


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
