### PR TITLE
DM-44091: For len(failed_quanta)>5, display counts and not data_ids

### DIFF
--- a/doc/changes/DM-44091.bugfix.md
+++ b/doc/changes/DM-44091.bugfix.md
@@ -1,0 +1,1 @@
+Previous version of the human-readable report only reported the first failed quantum by exiting the loop upon finding it. Following changes in `pipe_base`, display only counts of failures for `len(failed_quanta)>5`. Data ids can be found in yaml file listing error messages.

--- a/python/lsst/ctrl/mpexec/cli/script/report.py
+++ b/python/lsst/ctrl/mpexec/cli/script/report.py
@@ -79,14 +79,22 @@ def report(
                 dataset_table_rows.append(summary_dict[task]["outputs"][data_product])
                 data_products.append(data_product)
 
-            quanta_summary.append(
-                {
-                    "Task": task,
-                    "Failed Quanta": summary_dict[task]["failed_quanta"],
-                    "Blocked Quanta": summary_dict[task]["n_quanta_blocked"],
-                }
-            )
-
+            if len(summary_dict[task]["failed_quanta"]) > 5:
+                quanta_summary.append(
+                    {
+                        "Task": task,
+                        "Failed Quanta": len(summary_dict[task]["failed_quanta"]),
+                        "Blocked Quanta": summary_dict[task]["n_quanta_blocked"],
+                    }
+                )
+            else:
+                quanta_summary.append(
+                    {
+                        "Task": task,
+                        "Failed Quanta": summary_dict[task]["failed_quanta"],
+                        "Blocked Quanta": summary_dict[task]["n_quanta_blocked"],
+                    }
+                )
             if "errors" in summary_dict[task].keys():
                 error_summary.append({task: summary_dict[task]["errors"]})
         quanta = Table(quanta_summary)

--- a/tests/test_cliCmdReport.py
+++ b/tests/test_cliCmdReport.py
@@ -98,7 +98,6 @@ class ReportTest(unittest.TestCase):
         # Check that task0 and the failed quanta for task0 exist in the string
         self.assertIn("task0", result_hr.stdout)
         self.assertIn("Failed Quanta", result_hr.stdout)
-        self.assertIn("{'data_id': {'instrument': 'INSTR', 'detector': 0}}", result_hr.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
