### PR TITLE
DM-44368: Include number of expected instances in pipetask report task-level summary

### DIFF
--- a/doc/changes/DM-44368.feature.md
+++ b/doc/changes/DM-44368.feature.md
@@ -1,0 +1,1 @@
+Display successful and expected quanta in `pipetask report`.

--- a/python/lsst/ctrl/mpexec/cli/script/report.py
+++ b/python/lsst/ctrl/mpexec/cli/script/report.py
@@ -83,16 +83,20 @@ def report(
                 quanta_summary.append(
                     {
                         "Task": task,
-                        "Failed Quanta": len(summary_dict[task]["failed_quanta"]),
-                        "Blocked Quanta": summary_dict[task]["n_quanta_blocked"],
+                        "Failed": len(summary_dict[task]["failed_quanta"]),
+                        "Blocked": summary_dict[task]["n_quanta_blocked"],
+                        "Succeeded": summary_dict[task]["n_succeeded"],
+                        "Expected": summary_dict[task]["n_expected"],
                     }
                 )
             else:
                 quanta_summary.append(
                     {
                         "Task": task,
-                        "Failed Quanta": summary_dict[task]["failed_quanta"],
-                        "Blocked Quanta": summary_dict[task]["n_quanta_blocked"],
+                        "Failed": summary_dict[task]["failed_quanta"],
+                        "Blocked": summary_dict[task]["n_quanta_blocked"],
+                        "Succeeded": summary_dict[task]["n_succeeded"],
+                        "Expected": summary_dict[task]["n_expected"],
                     }
                 )
             if "errors" in summary_dict[task].keys():

--- a/tests/test_cliCmdReport.py
+++ b/tests/test_cliCmdReport.py
@@ -82,6 +82,7 @@ class ReportTest(unittest.TestCase):
             report_output_dict = yaml.load(f, Loader=SafeLoader)
         self.assertIsNotNone(report_output_dict["task0"])
         self.assertIsNotNone(report_output_dict["task0"]["failed_quanta"])
+        self.assertIsInstance(report_output_dict["task0"]["n_expected"], int)
 
         result_hr = self.runner.invoke(
             pipetask_cli,
@@ -97,7 +98,9 @@ class ReportTest(unittest.TestCase):
 
         # Check that task0 and the failed quanta for task0 exist in the string
         self.assertIn("task0", result_hr.stdout)
-        self.assertIn("Failed Quanta", result_hr.stdout)
+        self.assertIn("Failed", result_hr.stdout)
+        self.assertIn("Expected", result_hr.stdout)
+        self.assertIn("Succeeded", result_hr.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Depends on lsst/pipe_base#424.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
