### PR TITLE
DM-45340: Improve exception handling in quantum executors

### DIFF
--- a/python/lsst/ctrl/mpexec/quantumGraphExecutor.py
+++ b/python/lsst/ctrl/mpexec/quantumGraphExecutor.py
@@ -50,7 +50,9 @@ class QuantumExecutor(ABC):
     """
 
     @abstractmethod
-    def execute(self, task_node: TaskNode | TaskDef, /, quantum: Quantum) -> Quantum:
+    def execute(
+        self, task_node: TaskNode | TaskDef, /, quantum: Quantum
+    ) -> tuple[Quantum, QuantumReport | None]:
         """Execute single quantum.
 
         Parameters
@@ -66,6 +68,10 @@ class QuantumExecutor(ABC):
         -------
         quantum : `~lsst.daf.butler.Quantum`
             The quantum actually executed.
+        report : `~lsst.ctrl.mpexec.QuantumReport`
+            Structure describing the status of the execution of a quantum.
+            `None` is returned if implementation does not support this
+            feature.
 
         Notes
         -----
@@ -73,23 +79,6 @@ class QuantumExecutor(ABC):
         propagated to the caller of this method.
         """
         raise NotImplementedError()
-
-    def getReport(self) -> QuantumReport | None:
-        """Return execution report from last call to `execute`.
-
-        Returns
-        -------
-        report : `~lsst.ctrl.mpexec.QuantumReport`
-            Structure describing the status of the execution of a quantum.
-            `None` is returned if implementation does not support this
-            feature.
-
-        Raises
-        ------
-        RuntimeError
-            Raised if this method is called before `execute`.
-        """
-        return None
 
 
 class QuantumGraphExecutor(ABC):

--- a/python/lsst/ctrl/mpexec/simple_pipeline_executor.py
+++ b/python/lsst/ctrl/mpexec/simple_pipeline_executor.py
@@ -414,5 +414,5 @@ class SimplePipelineExecutor:
         # which might be useful for callers who want to check the state of the
         # repo in between.
         return (
-            single_quantum_executor.execute(qnode.task_node, qnode.quantum) for qnode in self.quantum_graph
+            single_quantum_executor.execute(qnode.task_node, qnode.quantum)[0] for qnode in self.quantum_graph
         )


### PR DESCRIPTION
This should solve an issue with exceptions happening at unpredictable locations in a SingleQuantumExecutor class. MPGraphExecutor in a single-process mode should also behave reasonably for random exceptions. Multi-process mode has more complex internal state. If a client of the code catches an exception and tries to reuse the executor, the state may be inconsistent, depending on where the exception happens.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
