### PR TITLE
DM-45724: Move handling of exiting exceptions to MPGraphExecutor

### DIFF
--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -807,7 +807,6 @@ class CmdLineFwk:
                 skipExistingIn=args.skip_existing_in,
                 clobberOutputs=args.clobber_outputs,
                 enableLsstDebug=args.enableLsstDebug,
-                exitOnKnownError=args.fail_fast,
                 resources=resources,
             )
 
@@ -991,7 +990,6 @@ class CmdLineFwk:
             butler=None,
             taskFactory=task_factory,
             enableLsstDebug=args.enableLsstDebug,
-            exitOnKnownError=args.fail_fast,
             limited_butler_factory=_butler_factory,
             resources=resources,
             assumeNoExistingOutputs=True,

--- a/python/lsst/ctrl/mpexec/reports.py
+++ b/python/lsst/ctrl/mpexec/reports.py
@@ -146,6 +146,8 @@ class QuantumReport(pydantic.BaseModel):
         exception: Exception,
         dataId: DataId,
         taskLabel: str,
+        *,
+        exitCode: int | None = None,
     ) -> QuantumReport:
         """Construct report instance from an exception and other pieces of
         data.
@@ -158,11 +160,15 @@ class QuantumReport(pydantic.BaseModel):
             Data ID of quantum.
         taskLabel : `str`
             Label of task.
+        exitCode : `int`, optional
+            Exit code for the process, used when it is known that the process
+            will exit with that exit code.
         """
         return cls(
             status=ExecutionStatus.FAILURE,
             dataId=dataId,
             taskLabel=taskLabel,
+            exitCode=exitCode,
             exceptionInfo=ExceptionInfo.from_exception(exception),
         )
 


### PR DESCRIPTION
This avoids unexpected process exits from SingleGraphExecutors level. MPGraphExecutor is a better place to handle application-level logic, potentially CmdLineFwk would be even better location, but some context is missing at that level.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
