### PR TITLE
DM-45894: Fix dimension universe instantiation in subprocesses

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: trailing-whitespace
       - id: check-toml
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.4.2
+    rev: 24.8.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -22,10 +22,10 @@ repos:
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.5.1
+    rev: v0.6.2
     hooks:
       - id: ruff
   - repo: https://github.com/numpy/numpydoc
-    rev: "v1.7.0"
+    rev: "v1.8.0"
     hooks:
       - id: numpydoc-validation

--- a/doc/changes/DM-45894.bugfix.md
+++ b/doc/changes/DM-45894.bugfix.md
@@ -1,0 +1,1 @@
+Fix for the bug in `pipetask run-qbb -j` which crashed if database dimension version is different from default version.


### PR DESCRIPTION
With run-qbb when dimension universe is not the default one, we need
to make sure that that universe is instantiated from a configuration
in a subprocess before unpickling anything that requires that universe.
The fix uses butler factory to do that, using its unpickle method,
and there is some complicated logic in executors to make sure that
unpickling of that factory happens first thing in a subprocess.
There may be an easier way to enforce that but it would require
interface changes for MPGraphExecutor or SingleQuantumExecutor.

Subprocess parameters are now pickled manually to guarantee that
logging is initialized properly in a subprocess before any complex
unpickling happens.

## Checklist

- [ ] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
