### PR TITLE
DM-46599: Stop using deprecated Butler methods

### DIFF
--- a/python/lsst/ctrl/mpexec/cli/script/cleanup.py
+++ b/python/lsst/ctrl/mpexec/cli/script/cleanup.py
@@ -26,7 +26,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-import re
 from typing import Any
 
 from lsst.daf.butler import Butler, CollectionType
@@ -141,8 +140,9 @@ def cleanup(
             collection, butler.registry.getCollectionType(collection).name
         )
         return result
-    regex = re.compile(collection + ".+")
-    to_consider = set(butler.registry.queryCollections(regex))
+    to_keep.add(collection)
+    glob = collection + "*"
+    to_consider = set(butler.registry.queryCollections(glob))
     to_remove = to_consider - to_keep
     for r in to_remove:
         if butler.registry.getCollectionType(r) == CollectionType.RUN:

--- a/python/lsst/ctrl/mpexec/separablePipelineExecutor.py
+++ b/python/lsst/ctrl/mpexec/separablePipelineExecutor.py
@@ -102,8 +102,10 @@ class SeparablePipelineExecutor:
         resources: lsst.pipe.base.ExecutionResources | None = None,
         raise_on_partial_outputs: bool = True,
     ):
-        self._butler = Butler.from_config(butler=butler, collections=butler.collections, run=butler.run)
-        if not self._butler.collections:
+        self._butler = Butler.from_config(
+            butler=butler, collections=butler.collections.defaults, run=butler.run
+        )
+        if not self._butler.collections.defaults:
             raise ValueError("Butler must specify input collections for pipeline.")
         if not self._butler.run:
             raise ValueError("Butler must specify output run for pipeline.")
@@ -215,7 +217,7 @@ class SeparablePipelineExecutor:
         needed, clients can use `len` to test if the returned graph is empty.
         """
         metadata = {
-            "input": self._butler.collections,
+            "input": self._butler.collections.defaults,
             "output_run": self._butler.run,
             "skip_existing_in": self._skip_existing_in,
             "skip_existing": bool(self._skip_existing_in),

--- a/python/lsst/ctrl/mpexec/simple_pipeline_executor.py
+++ b/python/lsst/ctrl/mpexec/simple_pipeline_executor.py
@@ -339,8 +339,8 @@ class SimplePipelineExecutor:
             ``where`` expression, keyed by the identifiers they replace.
         butler : `~lsst.daf.butler.Butler`
             Butler that manages all I/O.  `prep_butler` can be used to create
-            one.  Must have its `~Butler.run` and `~Butler.collections` not
-            empty and not `None`.
+            one.  Must have its `~Butler.run` and
+            `~Butler.collections.defaults` not empty and not `None`.
         resources : `~lsst.pipe.base.ExecutionResources`
             The resources available to each quantum being executed.
         raise_on_partial_outputs : `bool`, optional


### PR DESCRIPTION
Stop using Butler behavior that was deprecated in RFC-1040.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
