### PR TITLE
DM-48159 : Make Coverage import optional

### DIFF
--- a/doc/changes/DM-47159.bugfix.md
+++ b/doc/changes/DM-47159.bugfix.md
@@ -1,1 +1,3 @@
 Makes coverage package optional and lazy-loads it only when needed.
+Declares packaging extra for coverage, i.e., `pip install lsst-ctrl-mpexec[coverage]`.
+Updates minimum supported Python to 3.11 (dependency-driven change).

--- a/doc/changes/DM-47159.bugfix.md
+++ b/doc/changes/DM-47159.bugfix.md
@@ -1,0 +1,1 @@
+Makes coverage package optional and lazy-loads it only when needed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lsst-ctrl-mpexec"
-requires-python = ">=3.10.0"
+requires-python = ">=3.11.0"
 description = "Pipeline execution infrastructure for the Rubin Observatory LSST Science Pipelines."
 license = {text = "BSD 3-Clause License"}
 readme = "README.rst"
@@ -16,8 +16,9 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Astronomy",
 ]
 keywords = ["lsst"]
@@ -38,6 +39,7 @@ dynamic = ["version"]
 "Homepage" = "https://github.com/lsst/ctrl_mpexec"
 
 [project.optional-dependencies]
+coverage = ["coverage"]
 test = ["pytest >= 3.2"]
 
 [tool.setuptools.packages.find]

--- a/python/lsst/ctrl/mpexec/cli/cmd/commands.py
+++ b/python/lsst/ctrl/mpexec/cli/cmd/commands.py
@@ -148,9 +148,7 @@ def coverage_context(kwargs: dict[str, Any]) -> Iterator[None]:
     try:
         import coverage
     except ModuleNotFoundError:
-        raise click.ClickException(
-            "coverage was requested but the coverage package is not installed."
-        )
+        raise click.ClickException("coverage was requested but the coverage package is not installed.")
     with NamedTemporaryFile("w") as rcfile:
         rcfile.write(
             """

--- a/python/lsst/ctrl/mpexec/cli/cmd/commands.py
+++ b/python/lsst/ctrl/mpexec/cli/cmd/commands.py
@@ -33,7 +33,6 @@ from tempfile import NamedTemporaryFile
 from typing import Any
 
 import click
-import coverage
 import lsst.pipe.base.cli.opt as pipeBaseOpts
 from lsst.ctrl.mpexec import Report
 from lsst.ctrl.mpexec.showInfo import ShowInfo
@@ -145,6 +144,13 @@ def coverage_context(kwargs: dict[str, Any]) -> Iterator[None]:
     if not kwargs.pop("coverage", False):
         yield
         return
+    # Lazily import coverage only when we might need it
+    try:
+        import coverage
+    except ModuleNotFoundError:
+        raise click.ClickException(
+            "coverage was requested but the coverage package is not installed."
+        )
     with NamedTemporaryFile("w") as rcfile:
         rcfile.write(
             """

--- a/python/lsst/ctrl/mpexec/cli/cmd/commands.py
+++ b/python/lsst/ctrl/mpexec/cli/cmd/commands.py
@@ -29,6 +29,7 @@ import sys
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from functools import partial
+from importlib import import_module
 from tempfile import NamedTemporaryFile
 from typing import Any
 
@@ -146,7 +147,7 @@ def coverage_context(kwargs: dict[str, Any]) -> Iterator[None]:
         return
     # Lazily import coverage only when we might need it
     try:
-        import coverage
+        coverage = import_module("coverage")
     except ModuleNotFoundError:
         raise click.ClickException("coverage was requested but the coverage package is not installed.")
     with NamedTemporaryFile("w") as rcfile:

--- a/python/lsst/ctrl/mpexec/cli/opt/options.py
+++ b/python/lsst/ctrl/mpexec/cli/opt/options.py
@@ -54,7 +54,9 @@ debug_option = MWOptionDecorator(
     "--debug", help="Enable debugging output using lsstDebug facility (imports debug.py).", is_flag=True
 )
 
-coverage_option = MWOptionDecorator("--coverage", help="Enable coverage output.", is_flag=True)
+coverage_option = MWOptionDecorator(
+    "--coverage", help="Enable coverage output (requires coverage package).", is_flag=True
+)
 
 coverage_report_option = MWOptionDecorator(
     "--cov-report/--no-cov-report",


### PR DESCRIPTION
- Makes coverage import optional and lazy-loads it.
- Bump minimum Python to 3.11 (matching dependency for `daf_butler`).
- Add packaging extra option for coverage; i.e., pip users can specify `pip install lsst-ctrl-mpexec[coverage]`

## Checklist

- [ ] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
