### PR TITLE
DM-35396: Pass quantum ID down to executor so it can be used in provenance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: trailing-whitespace
       - id: check-toml
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.10.0
+    rev: 25.1.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
@@ -16,13 +16,13 @@ repos:
         # https://pre-commit.com/#top_level-default_language_version
         language_version: python3.11
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 6.0.0
     hooks:
       - id: isort
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.7.4
+    rev: v0.9.3
     hooks:
       - id: ruff
   - repo: https://github.com/numpy/numpydoc

--- a/doc/changes/DM-35396.api.rst
+++ b/doc/changes/DM-35396.api.rst
@@ -1,0 +1,1 @@
+The Quantum ID is now passed through the executors so it can be recorded in the provenance by ``QuantumContext``.

--- a/doc/changes/DM-35396.feature.rst
+++ b/doc/changes/DM-35396.feature.rst
@@ -1,0 +1,2 @@
+* Quantum metadata outputs now record the IDs of all output datasets.
+  This is stored in an ``outputs`` key.

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Module defining CmdLineFwk class and related methods.
-"""
+"""Module defining CmdLineFwk class and related methods."""
 
 from __future__ import annotations
 

--- a/python/lsst/ctrl/mpexec/quantumGraphExecutor.py
+++ b/python/lsst/ctrl/mpexec/quantumGraphExecutor.py
@@ -35,6 +35,8 @@ from typing import TYPE_CHECKING
 from .reports import QuantumReport, Report
 
 if TYPE_CHECKING:
+    import uuid
+
     from lsst.daf.butler import Quantum
     from lsst.pipe.base import QuantumGraph
     from lsst.pipe.base.pipeline_graph import TaskNode
@@ -50,7 +52,9 @@ class QuantumExecutor(ABC):
     """
 
     @abstractmethod
-    def execute(self, task_node: TaskNode, /, quantum: Quantum) -> tuple[Quantum, QuantumReport | None]:
+    def execute(
+        self, task_node: TaskNode, /, quantum: Quantum, quantum_id: uuid.UUID | None = None
+    ) -> tuple[Quantum, QuantumReport | None]:
         """Execute single quantum.
 
         Parameters
@@ -59,6 +63,8 @@ class QuantumExecutor(ABC):
             Task definition structure.
         quantum : `~lsst.daf.butler.Quantum`
             Quantum for this execution.
+        quantum_id : `uuid.UUID` or `None`, optional
+            The ID of the quantum to be executed.
 
         Returns
         -------

--- a/python/lsst/ctrl/mpexec/util.py
+++ b/python/lsst/ctrl/mpexec/util.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Few utility methods used by the rest of a package.
-"""
+"""Few utility methods used by the rest of a package."""
 
 __all__ = ["printTable", "filterTaskNodes", "subTaskIter"]
 

--- a/tests/test_cliCmdCleanup.py
+++ b/tests/test_cliCmdCleanup.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for ctrl_mpexec CLI cleanup subcommand.
-"""
+"""Unit tests for ctrl_mpexec CLI cleanup subcommand."""
 
 
 import os

--- a/tests/test_cliCmdPurge.py
+++ b/tests/test_cliCmdPurge.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for ctrl_mpexec CLI purge subcommand.
-"""
+"""Unit tests for ctrl_mpexec CLI purge subcommand."""
 
 
 import os

--- a/tests/test_cliUtils.py
+++ b/tests/test_cliUtils.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Unit tests for the daf_butler shared CLI options.
-"""
+"""Unit tests for the daf_butler shared CLI options."""
 
 import unittest
 

--- a/tests/test_cmdLineFwk.py
+++ b/tests/test_cmdLineFwk.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Simple unit test for cmdLineFwk module.
-"""
+"""Simple unit test for cmdLineFwk module."""
 
 import contextlib
 import logging

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -59,6 +59,7 @@ from lsst.pipe.base.graph import BuildId
 from lsst.pipe.base.tests.simpleQGraph import AddTaskFactoryMock, makeSimpleQGraph
 
 if TYPE_CHECKING:
+    import uuid
     from collections.abc import Iterator
     from multiprocessing.managers import ListProxy
 
@@ -88,7 +89,11 @@ class QuantumExecutorMock(QuantumExecutor):
             self.quanta = manager.list()
 
     def execute(  # type: ignore[override]
-        self, task_node: TaskNodeMock, /, quantum: QuantumMock  # type: ignore[override]
+        self,
+        task_node: TaskNodeMock,
+        /,
+        quantum: QuantumMock,  # type: ignore[override]
+        quantum_id: uuid.UUID | None = None,
     ) -> tuple[QuantumMock, QuantumReport | None]:
         _LOG.debug("QuantumExecutorMock.execute: task_node=%s dataId=%s", task_node, quantum.dataId)
         self._execute_called = True

--- a/tests/test_preExecInit.py
+++ b/tests/test_preExecInit.py
@@ -25,8 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Simple unit test for PreExecInit class.
-"""
+"""Simple unit test for PreExecInit class."""
 
 import contextlib
 import shutil


### PR DESCRIPTION
Requires lsst/pipe_base#464 and lsst/daf_butler#1147

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
