### PR TITLE
DM-49197: Fix astropy pformat_all deprecation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "lsst-pex-config",
     "lsst-pipe-base",
     "click",
-    "astropy",
+    "astropy >=7.0",
     "pydantic >=2,<3.0",
     "networkx",
     "psutil"

--- a/python/lsst/ctrl/mpexec/cmdLineFwk.py
+++ b/python/lsst/ctrl/mpexec/cmdLineFwk.py
@@ -902,7 +902,7 @@ class CmdLineFwk:
             self.report = Report(qgraphSummary=qgraph.getSummary())
             if _LOG.isEnabledFor(logging.INFO):
                 qg_task_table = self._generateTaskTable()
-                qg_task_table_formatted = "\n".join(qg_task_table.pformat_all())
+                qg_task_table_formatted = "\n".join(qg_task_table.pformat())
                 quanta_str = "quantum" if n_quanta == 1 else "quanta"
                 n_tasks = len(qgraph.taskGraph)
                 n_tasks_plural = "" if n_tasks == 1 else "s"


### PR DESCRIPTION
Astropy's Table.pformat_all() is now deprecated -- Table.pformat() is an exact replacement as of Astropy v7

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
