### PR TITLE
DM-49095: MPGraphExecutor: fix failure to fail

### DIFF
--- a/doc/changes/DM-49095.bugfix.rst
+++ b/doc/changes/DM-49095.bugfix.rst
@@ -1,0 +1,1 @@
+Fix failure to fail: not enough arguments for format string.

--- a/python/lsst/ctrl/mpexec/mpGraphExecutor.py
+++ b/python/lsst/ctrl/mpexec/mpGraphExecutor.py
@@ -557,7 +557,7 @@ class MPGraphExecutor(QuantumGraphExecutor):
                         fail_exit_code = exc.EXIT_CODE
                     raise
                 except InvalidQuantumError as exc:
-                    _LOG.fatal("Invalid quantum error for %s (%s): %s", task_node.label, qnode.quantum.dataId)
+                    _LOG.fatal("Invalid quantum error for %s (%s):", task_node.label, qnode.quantum.dataId)
                     _LOG.fatal(exc, exc_info=True)
                     fail_exit_code = exc.EXIT_CODE
                     raise


### PR DESCRIPTION
Not enough arguments for format string.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
