### PR TITLE
DM-48482: Build image rendering around `mermaid-py` for Mermaid diagrams

### DIFF
--- a/doc/changes/DM-48482.feature.rst
+++ b/doc/changes/DM-48482.feature.rst
@@ -1,0 +1,1 @@
+Added support for automatically determining the output format of Mermaid visualizations based on file extension, generating either definition files or images.

--- a/python/lsst/ctrl/mpexec/cli/script/build.py
+++ b/python/lsst/ctrl/mpexec/cli/script/build.py
@@ -129,10 +129,23 @@ def build(  # type: ignore
             )
 
     if pipeline_mermaid:
-        with open(pipeline_mermaid, "w") as stream:
+        # Determine output format based on file extension.
+        if pipeline_mermaid.endswith(".svg"):
+            output_format = "svg"
+            file_mode = "wb"
+        elif pipeline_mermaid.endswith(".png"):
+            output_format = "png"
+            file_mode = "wb"
+        else:  # Default to the text-based mmd format.
+            output_format = "mmd"
+            file_mode = "w"
+
+        with open(pipeline_mermaid, file_mode) as stream:
             visualization.show_mermaid(
                 pipeline.to_graph(butler.registry if butler is not None else None, visualization_only=True),
                 stream,
+                output_format=output_format,
+                width=4500 if output_format != "mmd" else None,
                 dataset_types=True,
                 task_classes="full",
             )


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
